### PR TITLE
Fix pyqtgraph colour configuration error

### DIFF
--- a/app/ui/plot_pane.py
+++ b/app/ui/plot_pane.py
@@ -131,7 +131,9 @@ class PlotPane(QtWidgets.QWidget):
     def _build_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        pg.setConfigOptions(antialias=True, background=None, foreground=None)
+        # Use pyqtgraph defaults for foreground/background colours to avoid
+        # invalid colour values being passed to mkColor.
+        pg.setConfigOptions(antialias=True)
 
         self._plot = pg.PlotWidget()
         self._plot.setObjectName("plot-pane")


### PR DESCRIPTION
## Summary
- stop overriding pyqtgraph foreground/background with None
- document why the defaults are used to avoid mkColor errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee9c0d8e448329b6ce25de3c4498c1