### PR TITLE
Restore TraceStyle antialias arg for compatibility

### DIFF
--- a/app/ui/plot_pane.py
+++ b/app/ui/plot_pane.py
@@ -21,7 +21,8 @@ class TraceStyle:
 
     color: QtGui.QColor
     width: float = 1.5
-    # antialias is not supported per-item in pyqtgraph 0.13.x; use global config
+    # Accepted for backwards compatibility but ignored by pyqtgraph 0.13.x.
+    antialias: bool = False
     show_in_legend: bool = True
 
 


### PR DESCRIPTION
## Summary
- add back the antialias field to TraceStyle so existing call sites remain valid while still being ignored by pyqtgraph

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee9d8f3d1c83298c37b4cda0671cbf