### PR TITLE
Improve plot performance with downsampling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -312,9 +312,13 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
 
     # ------------------------------------------------------------------
     def _load_default_samples(self) -> None:
-        for sample_file in sorted(SAMPLES_DIR.glob('sample_*.csv')):
-            if sample_file.exists():
-                self._ingest_path(sample_file)
+        self.plot.begin_bulk_update()
+        try:
+            for sample_file in sorted(SAMPLES_DIR.glob('sample_*.csv')):
+                if sample_file.exists():
+                    self._ingest_path(sample_file)
+        finally:
+            self.plot.end_bulk_update()
 
     # Actions -----------------------------------------------------------
     def open_file(self) -> None:


### PR DESCRIPTION
## Summary
- disable pyqtgraph antialiasing and remove curve fill to reduce render cost
- add peak-based downsampling with a 120k point cap per trace
- batch default sample loads to defer autoscale until after ingestion

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee9f3ac5008329a5664e3ec5307416