### PR TITLE
docs: start batch 2 workplan

### DIFF
--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -19,3 +19,13 @@
 - 2025-10-15: ✅ `mypy app --ignore-missing-imports`
 - 2025-10-15: ⚠️ `pytest -q --maxfail=1 --disable-warnings --cov=app --cov-report=term-missing` (fails: coverage plugin unavailable in test harness)
 - 2025-10-15: ✅ `pytest -q --maxfail=1 --disable-warnings`
+
+# Workplan — Batch 2 (2025-10-14)
+
+- [ ] Close out Batch 1 smoke-check (launch app, ingest CSV/FITS, toggle units, export manifest).
+- [ ] Capture current state of CI gates (ruff, mypy, pytest) on the latest branch.
+- [ ] Inventory pending documentation deltas required before next feature work.
+
+## Batch 2 QA Log
+
+- 2025-10-14: _(pending)_


### PR DESCRIPTION
## Summary
- add a Batch 2 section to the workplan with planned tasks for the next CI loop
- seed a placeholder QA log entry for the new batch

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68eec47e2b8483298b6d8505775f989f