### PR TITLE
Add smoke workflow regression coverage

### DIFF
--- a/docs/dev/ingest_pipeline.md
+++ b/docs/dev/ingest_pipeline.md
@@ -26,3 +26,7 @@
   This makes repeat loads instantaneous and ensures provenance is reproducible.
 - Provenance exports call `ProvenanceService.export_bundle`, which writes a
   manifest, a canonical CSV snapshot, and a PNG plot into the selected folder.
+
+## Smoke validation
+
+An automated smoke test (`tests/test_smoke_workflow.py`) spins up the preview shell, ingests the sample CSV and a generated FITS file, toggles units through `UnitsService`, and runs `ProvenanceService.export_bundle`. This guards the end-to-end ingest pipeline and manifest export behaviour without manual UI clicks.

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,0 +1,7 @@
+# Patch Notes
+
+## 2025-10-14
+
+- Added an automated smoke workflow test that instantiates the preview shell, ingests CSV/FITS data, exercises unit toggles, and exports a provenance bundle.
+- Centralised the reusable FITS fixture under `tests/conftest.py` to support regression suites.
+- Documented the new smoke validation loop for developers and provided a matching user checklist.

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -7,7 +7,7 @@
 - [x] Guard plot performance with LOD cap test.
 - [x] Update user and developer documentation (importing + ingest pipeline).
 - [x] Run lint/type/test suite locally; confirm CI configuration.
-- [ ] Smoke-check app launch, CSV/FITS ingest, unit toggle, export manifest.
+- [x] Smoke-check app launch, CSV/FITS ingest, unit toggle, export manifest (automated in tests/test_smoke_workflow.py).
 
 ## Batch 1 QA Log
 
@@ -22,7 +22,7 @@
 
 # Workplan — Batch 2 (2025-10-14)
 
-- [ ] Close out Batch 1 smoke-check (launch app, ingest CSV/FITS, toggle units, export manifest).
+- [x] Close out Batch 1 smoke-check (launch app, ingest CSV/FITS, toggle units, export manifest).
 - [ ] Capture current state of CI gates (ruff, mypy, pytest) on the latest branch.
 - [ ] Inventory pending documentation deltas required before next feature work.
 

--- a/docs/user/importing.md
+++ b/docs/user/importing.md
@@ -25,3 +25,7 @@ Imported spectra always appear in canonical units inside the application. Use
  the unit toggle on the toolbar to view alternative axes without mutating the
  underlying data. The raw source file remains untouched in the provenance
  bundle created during export.
+
+## Quick smoke workflow
+
+Run File → Open on `samples/sample_spectrum.csv`, toggle the units toolbar to Ångström/Transmittance, and export a manifest via File → Export Manifest. This mirrors the automated regression in `tests/test_smoke_workflow.py`, ensuring the ingest pipeline and provenance export are healthy.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,41 @@
 """Test configuration for ensuring the application package is importable."""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    from astropy.io import fits
+except ModuleNotFoundError:  # pragma: no cover - optional dep on CI
+    fits = None
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture()
+def mini_fits(tmp_path: Path) -> Path:
+    """Create a minimal FITS file for ingestion smoke tests."""
+
+    if fits is None:
+        pytest.skip("astropy is required for FITS ingestion tests")
+
+    wavelengths = np.array([500.0, 600.0, 700.0])
+    flux = np.array([0.1, 0.2, 0.3])
+    columns = [
+        fits.Column(name="WAVELENGTH", array=wavelengths, format="D", unit="nm"),
+        fits.Column(name="FLUX", array=flux, format="D", unit="erg/s/cm2/angstrom"),
+    ]
+    table = fits.BinTableHDU.from_columns(columns)
+    table.header["OBJECT"] = "MiniFixture"
+    table.header["INSTRUME"] = "TestSpec"
+    table.header["BUNIT"] = "erg/s/cm2/angstrom"
+
+    path = tmp_path / "mini.fits"
+    fits.HDUList([fits.PrimaryHDU(), table]).writeto(path)
+    return path

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
 import numpy as np
-import pytest
-from astropy.io import fits
 
 from app.services import DataIngestService, UnitsService
 
@@ -30,23 +28,6 @@ def test_percent_transmittance_conversion():
     assert np.allclose(spectrum.y, expected)
 
 
-@pytest.fixture()
-def mini_fits(tmp_path: Path) -> Path:
-    wavelengths = np.array([500.0, 600.0, 700.0])
-    flux = np.array([0.1, 0.2, 0.3])
-    columns = [
-        fits.Column(name="WAVELENGTH", array=wavelengths, format="D", unit="nm"),
-        fits.Column(name="FLUX", array=flux, format="D", unit="erg/s/cm2/angstrom"),
-    ]
-    table = fits.BinTableHDU.from_columns(columns)
-    table.header["OBJECT"] = "MiniFixture"
-    table.header["INSTRUME"] = "TestSpec"
-    table.header["BUNIT"] = "erg/s/cm2/angstrom"
-    path = tmp_path / "mini.fits"
-    fits.HDUList([fits.PrimaryHDU(), table]).writeto(path)
-    return path
-
-
 def test_fits_ingest_fixture(mini_fits: Path):
     service = build_ingest_service()
     spectrum = service.ingest(mini_fits)
@@ -55,4 +36,3 @@ def test_fits_ingest_fixture(mini_fits: Path):
     assert ingest_meta["source_path"].endswith("mini.fits")
     assert np.isclose(spectrum.x[0], 500.0)
     assert spectrum.metadata.get("original_flux_unit") == "erg/s/cm2/angstrom"
-

--- a/tests/test_smoke_workflow.py
+++ b/tests/test_smoke_workflow.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    from app.main import SpectraMainWindow
+    from app.qt_compat import get_qt
+except ImportError as exc:  # pragma: no cover - optional on headless CI
+    SpectraMainWindow = None  # type: ignore[assignment]
+    _qt_import_error = exc
+    QtCore = QtGui = QtWidgets = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised via smoke test
+    _qt_import_error = None
+    QtCore, QtGui, QtWidgets, _ = get_qt()
+
+from app.services import DataIngestService, ProvenanceService, UnitsService
+
+def _ensure_app() -> QtWidgets.QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_smoke_ingest_toggle_and_export(tmp_path: Path, mini_fits: Path) -> None:
+    """Exercise the core happy path: launch shell, ingest, convert units, export manifest."""
+
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        assert window.windowTitle().startswith("Spectra")
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()
+
+    units = UnitsService()
+    ingest = DataIngestService(units)
+    provenance = ProvenanceService(app_version="0.2-smoke")
+
+    csv_spec = ingest.ingest(Path("samples/sample_spectrum.csv"))
+    fits_spec = ingest.ingest(mini_fits)
+
+    supported = ingest.supported_extensions()
+    assert supported.get(".csv") == "CsvImporter"
+    assert supported.get(".fits") == "FitsImporter"
+
+    angstrom_view = csv_spec.view(units, "angstrom", "transmittance")
+    assert np.allclose(angstrom_view["x"], csv_spec.x * 10.0)
+    assert np.allclose(angstrom_view["y"], np.power(10.0, -csv_spec.y))
+
+    roundtrip_x, roundtrip_y, meta = units.to_canonical(
+        angstrom_view["x"], angstrom_view["y"], "angstrom", "transmittance"
+    )
+    assert np.allclose(roundtrip_x, csv_spec.x)
+    assert np.allclose(roundtrip_y, csv_spec.y)
+    assert meta["source_units"] == {"x": "angstrom", "y": "transmittance"}
+
+    bundle_dir = tmp_path / "export"
+    manifest_path = bundle_dir / "manifest.json"
+    png_bytes = b"\x89PNG\r\n"
+
+    bundle = provenance.export_bundle(
+        [csv_spec, fits_spec], manifest_path, png_writer=lambda path: path.write_bytes(png_bytes)
+    )
+
+    assert bundle["manifest_path"].exists()
+    manifest = bundle["manifest"]
+    importer_ids = {entry["metadata"]["ingest"]["importer"] for entry in manifest["sources"]}
+    assert {"CsvImporter", "FitsImporter"}.issubset(importer_ids)
+
+    csv_contents = bundle["csv_path"].read_text(encoding="utf-8")
+    assert "wavelength_nm" in csv_contents
+    assert str(csv_spec.x[0]) in csv_contents
+
+    assert bundle["png_path"].read_bytes() == png_bytes


### PR DESCRIPTION
## What changed
- Added an end-to-end smoke test that instantiates the preview shell, ingests sample CSV/FITS spectra, toggles units, and exports a provenance bundle.
- Centralised the reusable FITS fixture in `tests/conftest.py` and refreshed ingest tests to use it.
- Documented the new smoke validation flow for developers and users, and recorded the update in patch notes and the workplan checklist.

## How verified
- Manual execution of the automated smoke pytest to ensure the UI can be created offscreen and services integrate end-to-end.

## Tests added
- `tests/test_smoke_workflow.py`

## Docs updated
- docs/dev/ingest_pipeline.md
- docs/user/importing.md
- docs/history/PATCH_NOTES.md
- docs/reviews/workplan.md

## Perf notes
- No performance-impacting changes.

## Follow-ups
- Capture the latest CI gate outputs for Batch 2 and review remaining documentation deltas.

------
https://chatgpt.com/codex/tasks/task_e_68eec735404483298d674e444cc31809