### PR TITLE
Document documentation gaps before next feature batch

### DIFF
--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -5,6 +5,7 @@
 - Added an automated smoke workflow test that instantiates the preview shell, ingests CSV/FITS data, exercises unit toggles, and exports a provenance bundle.
 - Centralised the reusable FITS fixture under `tests/conftest.py` to support regression suites.
 - Documented the new smoke validation loop for developers and provided a matching user checklist.
+- Captured a documentation inventory outlining remaining user/dev guide gaps ahead of the next feature batch.
 
 ## 2025-10-15
 

--- a/docs/reviews/doc_inventory_2025-10-14.md
+++ b/docs/reviews/doc_inventory_2025-10-14.md
@@ -1,0 +1,53 @@
+# Documentation Inventory — 2025-10-14
+
+## Purpose
+
+This inventory captures the documentation gaps that remain before the next
+feature sprint. It compares the requirements from the master product prompt
+with the current contents of `docs/` and identifies concrete follow-up tasks.
+
+## Summary of Required Deltas
+
+- Establish a **user handbook set** covering units/conversions, plot tools,
+  and provenance/export workflows.
+- Flesh out the **developer knowledge base** with provenance schema details,
+  testing workflow guidance, and feature flag conventions.
+- Expand **history/process artifacts** so recurring workplans and release
+  cadence are traceable from the repository alone.
+
+## User-Facing Documentation
+
+| Theme | Gap | Suggested Artifact |
+| --- | --- | --- |
+| Units & conversions | No dedicated user walkthrough for nm/Å/µm/cm⁻¹ toggles or idempotent behaviour expectations. | `docs/user/units_and_conversions.md` outlining the toggle UI, mathematical relationships, and troubleshooting. |
+| Plot interaction | Lack of instructions for LOD behaviour, crosshair usage, and export snapshots. | `docs/user/plot_tools.md` describing interactive controls, performance tips, and limitations (e.g., anti-alias defaults). |
+| Provenance exports | Existing importing guide does not explain manifest bundle contents or citation expectations. | Section or standalone page (e.g., `docs/user/provenance.md`) covering export manifests, citation formats, and how raw files are preserved. |
+
+## Developer Documentation
+
+| Theme | Gap | Suggested Artifact |
+| --- | --- | --- |
+| Provenance schema | No developer-facing specification for the manifest JSON structure or expected metadata fields. | `docs/dev/provenance_schema.md` documenting keys, sample payloads, and extension rules. |
+| Feature flags | Lacking guidance on introducing gated providers/services and their default-off expectations. | Add section to `docs/dev/ingest_pipeline.md` or a new `docs/dev/feature_flags.md`. |
+| Test strategy | Current CI guide lists commands but not fixtures, random seeds, or coverage expectations. | Expand `docs/dev/ci_gates.md` with deterministic-testing practices and coverage requirements. |
+| Data fixtures | No canonical location policy for generated FITS/JCAMP fixtures or runtime generation helpers. | Brief note in `docs/dev/testing_fixtures.md` describing fixture strategy and generation at runtime. |
+
+## History & Process Artifacts
+
+- **Workplan hygiene**: Continue appending batches in `docs/reviews/workplan.md`
+  with completion notes and link them back to inventories like this document.
+- **Patch cadence**: Ensure `docs/history/PATCH_NOTES.md` receives an entry for
+  each working day summarising both code and documentation deltas.
+- **AI/dev logs**: Resume updates to `docs/history/KNOWLEDGE_LOG.md` or
+  `docs/ai_log/` so rationale for documentation priorities is recorded.
+
+## Next Steps
+
+1. Prioritise authoring the user-facing unit/plot/provenance guides so the
+   application UI contract is discoverable without reading source code.
+2. Draft the provenance schema reference in tandem with any upcoming exporter
+   enhancements to keep the manifest authoritative.
+3. Backfill test and fixture documentation before adding new ingest or fetch
+   providers, ensuring contributors understand runtime-generated data
+   expectations.
+

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -24,7 +24,7 @@
 
 - [x] Close out Batch 1 smoke-check (launch app, ingest CSV/FITS, toggle units, export manifest).
 - [x] Capture current state of CI gates (ruff, mypy, pytest) on the latest branch.
-- [ ] Inventory pending documentation deltas required before next feature work.
+- [x] Inventory pending documentation deltas required before next feature work. (See `docs/reviews/doc_inventory_2025-10-14.md`.)
 
 ## Batch 2 QA Log
 


### PR DESCRIPTION
## What changed
- Added a documentation inventory capturing the pending user/developer/history doc gaps for the next sprint.
- Marked the Batch 2 workplan item as complete with a pointer to the new inventory artifact.
- Logged the inventory effort in the running patch notes for 2025-10-14.

## How verified
- `./.venv/Scripts/pytest -q` *(fails in local container: virtual environment not provisioned)*

## Tests added
- None (documentation-only change).

## Docs updated
- `docs/reviews/doc_inventory_2025-10-14.md`
- `docs/reviews/workplan.md`
- `docs/history/PATCH_NOTES.md`

## Perf notes
- Not applicable (documentation change).

## Follow-ups
- Author the new user guides for units/conversions, plot tools, and provenance exports per the inventory.
- Draft provenance schema and fixture/feature-flag developer notes referenced in the inventory.
- Resume updates to knowledge/AI logs to track documentation rationale.


------
https://chatgpt.com/codex/tasks/task_e_68eed96977488329a0e37e63f1841b22