### PR TITLE
Add quickstart user guide and refresh documentation planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The launcher script automatically:
 - Installs all dependencies
 - Launches the application
 
+Prefer a guided walkthrough? Follow the step-by-step [Spectra App Quickstart](docs/user/quickstart.md) to launch the app, ingest sample data, toggle units, and export provenance bundles.
+
 ### Manual Installation
 
 1. **Create Virtual Environment**:

--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -79,3 +79,15 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
   history.  When in doubt, write more rather than less.
 * **Citation**: Use tether IDs to cite official documents, academic papers or
   authoritative resources.  This ensures that claims can be verified.
+
+---
+
+## 2025-10-14 20:00 – Documentation
+
+**Author**: agent
+
+**Context**: User-facing onboarding documentation and planning artifacts.
+
+**Summary**: Authored the first-run quickstart (`docs/user/quickstart.md`) so new operators can launch the desktop build, ingest bundled spectra, validate unit toggles, and export a provenance bundle without guesswork. Updated the README quick start section to highlight the guide and extended the Batch 3 workplan to track remaining documentation gaps aligned with the inventory. Captured the work in patch notes for traceability.
+
+**References**: `docs/user/quickstart.md`, `README.md`, `docs/reviews/workplan.md`, `docs/history/PATCH_NOTES.md`.

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,11 @@
 # Patch Notes
 
+## 2025-10-14 (Quickstart Guide) (8:00 pm)
+
+- Added `docs/user/quickstart.md` with a step-by-step walkthrough covering launch, ingest, unit toggles, and provenance export using the bundled sample spectrum.
+- Updated the Batch 3 workplan to track remaining documentation gaps and recorded the pytest run that validates the smoke workflow.
+- Linked upcoming documentation sprint items back to the inventory for traceability.
+
 ## 2025-10-14 (7:20 pm)
 
 - Logged the latest CI gate outcomes (lint, type-check, pytest) and noted the missing coverage plugin.

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -32,3 +32,14 @@
 - 2025-10-15: ✅ `mypy app --ignore-missing-imports`
 - 2025-10-15: ❌ `pytest -q --maxfail=1 --disable-warnings --cov=app --cov-report=term-missing` (fails: pytest-cov plugin missing)
 - 2025-10-15: ✅ `pytest -q --maxfail=1 --disable-warnings`
+
+# Workplan — Batch 3 (2025-10-14)
+
+- [x] Draft user quickstart walkthrough covering launch → ingest → unit toggle → export.
+- [ ] Author units & conversions reference with idempotency callouts.
+- [ ] Document plot interaction tools and LOD expectations.
+- [ ] Expand importing guide with provenance export appendix.
+
+## Batch 3 QA Log
+
+- 2025-10-14: ✅ `pytest -q`

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,0 +1,51 @@
+# Spectra App Quickstart
+
+This walkthrough gets you from launch to a complete provenance export using only the files bundled with the Spectra App. It assumes you are running on Windows with Python 3.11+ available.
+
+## 1. Launch the application
+
+1. Open the repository folder in Explorer.
+2. Double-click **RunSpectraApp.cmd**. The helper script builds/updates the virtual environment if needed and starts the desktop UI.
+3. Wait for the main window to appear. The plot pane will be empty until you ingest data.
+
+> **Troubleshooting**
+> - If the script cannot find Python 3.11+, install it from [python.org](https://www.python.org/downloads/).
+> - To force a clean environment rebuild, run `RunSpectraApp.cmd -Reinstall` from PowerShell.
+
+## 2. Load the bundled sample spectrum
+
+1. Choose **File → Open…**.
+2. Navigate to the repository's `samples` directory.
+3. Select `sample_spectrum.csv` and click **Open**.
+4. Confirm the detected units in the preview banner. The importer normalises the axis to nanometres while keeping the source file untouched in the cache directory.
+
+Once the ingest completes, the spectrum appears in the plot pane and in the spectra list on the left-hand sidebar.
+
+## 3. Explore unit toggles
+
+1. Locate the **Units** toolbar dropdown above the plot.
+2. Switch the wavelength axis to Ångström, micrometre, or wavenumber (cm⁻¹).
+3. Observe that the plot updates instantly without mutating the stored data. You can toggle back to nanometres at any time—unit conversions are idempotent and guaranteed by automated regression tests (`tests/test_units_roundtrip.py`).
+
+## 4. Inspect metadata and provenance
+
+1. Select the ingested spectrum in the spectra list.
+2. Open the **Inspector** panel (View → Inspector) if it is not already visible.
+3. Review the **Metadata** and **Provenance** tabs for acquisition details, detected units, and file locations.
+
+## 5. Export a provenance bundle
+
+1. Choose **File → Export → Manifest Bundle…**.
+2. Pick an empty directory (for example, `Desktop\spectra-export-test`).
+3. After export completes, inspect the folder. It contains:
+   - The canonicalised CSV representing the current plot view.
+   - `manifest.json` with hashes, ingest timestamps, units, and source metadata.
+   - `provenance/` with the untouched raw source file.
+
+This mirrors the automated smoke workflow in `tests/test_smoke_workflow.py`. Run that test any time you need to verify the ingest → unit toggle → export pipeline.
+
+## 6. Next steps
+
+- Continue exploring the `samples/` directory for additional datasets.
+- Review [docs/user/importing.md](importing.md) for deeper coverage of supported formats.
+- Track upcoming documentation deliverables in [docs/reviews/doc_inventory_2025-10-14.md](../reviews/doc_inventory_2025-10-14.md).


### PR DESCRIPTION
## What changed
- added a user-facing quickstart walkthrough covering launch, ingest, unit toggles, and provenance export
- highlighted the new guide from the README quick start section and logged the work in knowledge + patch notes
- extended the Batch 3 workplan checklist with remaining documentation gaps and recorded the pytest run

## How verified
- `pytest -q`

## Tests added
- none (documentation-only change)

## Docs updated
- docs/user/quickstart.md
- README.md
- docs/reviews/workplan.md
- docs/history/PATCH_NOTES.md
- docs/history/KNOWLEDGE_LOG.md

## Perf notes
- n/a

## Follow-ups
- author the user units & conversions reference
- document plot interaction tools and LOD behaviour
- expand importing guide with provenance export appendix

------
https://chatgpt.com/codex/tasks/task_e_68eedd0669888329873a7998156f3860