### PR TITLE
Add units conversion reference documentation

### DIFF
--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,10 @@
 # Patch Notes
 
+## 2025-10-14 (Units Reference) (7:38 pm)
+
+- Authored `docs/user/units_reference.md` to document supported spectral units, idempotent conversions, and provenance guarantees.
+- Linked the quickstart guide to the new reference and marked the Batch 3 workplan item complete.
+
 ## 2025-10-14 (Quickstart Guide) (8:00 pm)
 
 - Added `docs/user/quickstart.md` with a step-by-step walkthrough covering launch, ingest, unit toggles, and provenance export using the bundled sample spectrum.

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -36,7 +36,7 @@
 # Workplan — Batch 3 (2025-10-14)
 
 - [x] Draft user quickstart walkthrough covering launch → ingest → unit toggle → export.
-- [ ] Author units & conversions reference with idempotency callouts.
+- [x] Author units & conversions reference with idempotency callouts (`docs/user/units_reference.md`).
 - [ ] Document plot interaction tools and LOD expectations.
 - [ ] Expand importing guide with provenance export appendix.
 

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -48,4 +48,5 @@ This mirrors the automated smoke workflow in `tests/test_smoke_workflow.py`. Run
 
 - Continue exploring the `samples/` directory for additional datasets.
 - Review [docs/user/importing.md](importing.md) for deeper coverage of supported formats.
+- Consult the [Units & Conversions Reference](units_reference.md) for detailed information on idempotent toggles and canonical storage.
 - Track upcoming documentation deliverables in [docs/reviews/doc_inventory_2025-10-14.md](../reviews/doc_inventory_2025-10-14.md).

--- a/docs/user/units_reference.md
+++ b/docs/user/units_reference.md
@@ -1,0 +1,32 @@
+# Units & Conversions Reference
+
+Spectra App normalises all spectral axes to nanometres (nm) internally while preserving the original units provided by the data source. This reference explains the available unit options, how conversions are applied, and what guarantees the application provides for round-trip idempotency.
+
+## Supported spectral units
+
+| Label in UI | Physical dimension | Canonical symbol |
+|-------------|--------------------|------------------|
+| Nanometres  | Wavelength         | nm               |
+| Angstroms   | Wavelength         | Å                |
+| Micrometres | Wavelength         | µm               |
+| Wavenumber  | Reciprocal length  | cm⁻¹             |
+
+All values are stored in nm internally, which keeps the unit canon consistent across the application.
+
+## Conversion guarantees
+
+- **Round-trip idempotency**: Switching between any two supported units and back to the starting unit will yield the original values within floating-point tolerances. Automated regression tests enforce this behaviour.
+- **Precision preservation**: Conversions use high-precision constants (e.g., 10 Å = 1 nm, 1000 nm = 1 µm) and avoid cumulative rounding by always converting via the canonical nm representation.
+- **Provenance visibility**: Every conversion action is logged to the session manifest so exported bundles retain the original unit context and the canonical nm data.
+
+## Practical guidance
+
+- Prefer capturing raw data in its native units; the importer records both the raw axis metadata and the canonical nm values.
+- When scripting automated ingest via the CLI, include unit annotations—omitted units default to nm.
+- For wavenumber data (cm⁻¹), the app automatically converts to wavelength by inverting the values before normalising to nm. The inverse operation is applied when switching the UI back to cm⁻¹.
+- If you notice unexpected rounding, verify that upstream data is not truncated before import; Spectra App will faithfully preserve precision once the data is inside the store.
+
+## Further reading
+
+- [Quickstart](./quickstart.md) — outlines how to ingest data and toggle units during a session.
+- [Importing guide](./importing.md) — details metadata requirements for unit annotations and provenance capture.


### PR DESCRIPTION
## What changed
- Added a dedicated Units & Conversions reference covering supported axes, idempotent round-trips, and provenance logging.
- Linked the user quickstart to the new guide and marked the Batch 3 workplan item complete.
- Logged the documentation update in the patch notes for 2025-10-14.

## How verified
- Manual documentation review.

## Tests added
- None.

## Docs updated
- Yes — user docs, workplan, and patch notes.

## Perf notes
- No runtime-impacting changes.

## Follow-ups
- Document plot interaction tools and LOD expectations.
- Expand importing guide with provenance export appendix.


------
https://chatgpt.com/codex/tasks/task_e_68eede9c69c88329ad251a93fdbf5160