### PR TITLE
Document plot interactions and wire crosshair toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,10 @@ python -m PyInstaller spectra_app.spec
 ## 📚 Documentation Index
 
 ### User Documentation
-- `docs/user/quickstart.md` - Getting started guide
-- `docs/user/file_types.md` - Supported formats and import procedures
-- `docs/user/units_conversions.md` - Unit system explanation
-- `docs/user/analysis_tools.md` - Mathematical operations guide
-- `docs/user/export_guide.md` - Export formats and provenance
+- `docs/user/quickstart.md` - Getting started walkthrough from launch to export
+- `docs/user/importing.md` - Supported formats and ingest workflow details
+- `docs/user/plot_tools.md` - Plot interactions, crosshair usage, and LOD behaviour
+- `docs/user/units_reference.md` - Unit system guarantees and toggle guidance
 
 ### Developer Resources
 - `docs/dev/architecture.md` - System architecture overview

--- a/app/main.py
+++ b/app/main.py
@@ -90,6 +90,11 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         view_menu.addAction(self.inspector_dock.toggleViewAction())
         view_menu.addAction(self.log_dock.toggleViewAction())
         view_menu.addSeparator()
+        self.reset_plot_action = QtGui.QAction("Reset Plot", self)
+        self.reset_plot_action.setShortcut(QtGui.QKeySequence("Ctrl+Shift+A"))
+        self.reset_plot_action.triggered.connect(self.plot.autoscale)
+        view_menu.addAction(self.reset_plot_action)
+        view_menu.addSeparator()
         self.data_table_action = QtGui.QAction("Show Data Table", self, checkable=True)
         self.data_table_action.triggered.connect(self._toggle_data_table)
         view_menu.addAction(self.data_table_action)
@@ -261,6 +266,8 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
 
         self.action_cursor = QtGui.QAction("Cursor", self)
         self.action_cursor.setCheckable(True)
+        self.action_cursor.setChecked(True)
+        self.action_cursor.toggled.connect(self.plot.set_crosshair_visible)
         toolbar.addAction(self.action_cursor)
 
         self.action_peak = QtGui.QAction("Peak", self)

--- a/app/ui/plot_pane.py
+++ b/app/ui/plot_pane.py
@@ -42,6 +42,7 @@ class PlotPane(QtWidgets.QWidget):
         self._traces: Dict[str, Dict[str, object]] = {}
         self._order: list[str] = []
         self._max_points = 120_000
+        self._crosshair_visible = True
         self._build_ui()
 
     # ------------------------------------------------------------------
@@ -132,6 +133,18 @@ class PlotPane(QtWidgets.QWidget):
         exporter.parameters()["width"] = width
         exporter.export(str(path))
 
+    def set_crosshair_visible(self, visible: bool) -> None:
+        """Show or hide the crosshair guide."""
+
+        self._crosshair_visible = bool(visible)
+        self._vline.setVisible(self._crosshair_visible)
+        self._hline.setVisible(self._crosshair_visible)
+
+    def is_crosshair_visible(self) -> bool:
+        """Return True when the crosshair guide is visible."""
+
+        return self._crosshair_visible
+
     # ------------------------------------------------------------------
     # Internal helpers
     def _build_ui(self) -> None:
@@ -157,6 +170,7 @@ class PlotPane(QtWidgets.QWidget):
         self._hline = pg.InfiniteLine(angle=0, movable=False, pen=pen)
         self._plot.addItem(self._vline, ignoreBounds=True)
         self._plot.addItem(self._hline, ignoreBounds=True)
+        self.set_crosshair_visible(self._crosshair_visible)
         self._proxy = pg.SignalProxy(
             self._plot.scene().sigMouseMoved,
             rateLimit=60,

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,12 @@
 # Patch Notes
 
+## 2025-10-14 (Plot Interaction Guide) (8:45 pm)
+
+- Added `docs/user/plot_tools.md` covering pan/zoom gestures, crosshair usage, legend management, and the 120k-point LOD cap.
+- Wired the Cursor toolbar toggle and new **View → Reset Plot** action to the plot pane so the documentation matches the UI.
+- Linked the new guide from the quickstart and README documentation index.
+- Extended the plot performance stub tests to exercise the crosshair visibility API.
+
 ## 2025-10-14 (Units Reference) (7:38 pm)
 
 - Authored `docs/user/units_reference.md` to document supported spectral units, idempotent conversions, and provenance guarantees.

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -37,7 +37,7 @@
 
 - [x] Draft user quickstart walkthrough covering launch → ingest → unit toggle → export.
 - [x] Author units & conversions reference with idempotency callouts (`docs/user/units_reference.md`).
-- [ ] Document plot interaction tools and LOD expectations.
+- [x] Document plot interaction tools and LOD expectations (`docs/user/plot_tools.md`).
 - [ ] Expand importing guide with provenance export appendix.
 
 ## Batch 3 QA Log

--- a/docs/user/plot_tools.md
+++ b/docs/user/plot_tools.md
@@ -1,0 +1,44 @@
+# Plot Interaction Tools & LOD Behaviour
+
+The Spectra plot pane is powered by PyQtGraph and optimised for working with large spectral traces. This guide covers the day-to-day tools available for inspecting data, plus what to expect from the built-in level-of-detail (LOD) safeguards that preserve interactivity on dense datasets.
+
+## Quick reference: mouse & keyboard gestures
+
+| Action | Gesture | Notes |
+| --- | --- | --- |
+| Pan | Left mouse drag | Holds the current zoom level while moving the view. |
+| Box zoom | Right mouse drag or hold `Ctrl` while dragging left | Draws a rectangle to focus on a specific wavelength span. |
+| Wheel zoom | Scroll wheel (focus follows cursor) | Zooms towards the pointer so you can dive into narrow features quickly. |
+| Reset view | Press `Ctrl+Shift+A` or click **View → Reset Plot** | Re-applies auto-range to every visible trace. |
+| Toggle crosshair | Toolbar **Cursor** button | When enabled, the vertical/horizontal guides follow the pointer and update the status bar readout. |
+| Snapshot | **File → Export → Manifest** | Captures a PNG of the current view alongside provenance assets. |
+
+> **Tip**: The datasets dock includes a visibility checkbox for every trace. Hiding derived overlays before zooming on faint features reduces clutter and keeps the legend focused.
+
+## Reading the status bar and inspector
+
+Moving the mouse over the plot updates the status bar with the current cursor coordinates in the active display units. When the Inspector dock is visible, the **Info** tab also highlights the selected trace's sample count, value range, and original units so you can confirm whether a spike is physical or an artefact.
+
+The **Cursor** toolbar toggle controls whether the crosshair guides are visible. Leave it enabled when measuring peaks; turn it off if you need an unobstructed screenshot.
+
+## Legend & trace management
+
+Every trace that remains visible has a matching entry in the floating legend anchored to the top-left corner of the plot. Rename a dataset from the Inspector's alias field to update the legend label in real time. To declutter dense overlays, uncheck the visibility toggle in the Datasets dock—the trace disappears from the canvas and the legend until you re-enable it.
+
+## Level-of-detail safeguards
+
+High-resolution spectra can contain millions of samples. Rendering every point would make panning and zooming sluggish, so the plot pane automatically enforces a peak-envelope LOD cap:
+
+- Up to **120,000** points per trace render exactly as provided.
+- Above that threshold, the x-axis is segmented and each block collapses into alternating min/max samples that preserve peaks.
+- The tail of a trace that does not align perfectly with the segmentation is appended without modification so you never lose edge information.
+
+This process is entirely view-layer only—no data is mutated or discarded. Exports (CSV and manifest bundles) always include the full-resolution series, and unit conversions continue to operate on the canonical nanometre axis. If you need to inspect individual samples, open the **View → Show Data Table** panel to browse the raw numbers alongside the plot.
+
+## Performance best practices
+
+- Prefer hiding traces you are not actively comparing; fewer visible overlays result in shallower legend hierarchies and less work for the renderer.
+- Use wheel zoom to home in on features before switching units—wavenumber axes invert the direction of increasing values, and staying zoomed keeps orientation consistent.
+- For extremely dense imported files, let the initial draw settle for a second before interacting; once cached, subsequent pans and zooms reuse the downsampled envelope.
+
+Following these practices keeps the UI responsive even with multi-megabyte spectral stacks, while the provenance export pipeline continues to capture the unmodified data stream.

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -48,5 +48,6 @@ This mirrors the automated smoke workflow in `tests/test_smoke_workflow.py`. Run
 
 - Continue exploring the `samples/` directory for additional datasets.
 - Review [docs/user/importing.md](importing.md) for deeper coverage of supported formats.
+- Learn how to pan, zoom, and interpret the legend in [Plot Interaction Tools & LOD Behaviour](plot_tools.md).
 - Consult the [Units & Conversions Reference](units_reference.md) for detailed information on idempotent toggles and canonical storage.
 - Track upcoming documentation deliverables in [docs/reviews/doc_inventory_2025-10-14.md](../reviews/doc_inventory_2025-10-14.md).

--- a/tests/test_plot_perf_stub.py
+++ b/tests/test_plot_perf_stub.py
@@ -32,3 +32,25 @@ def test_plotpane_downsamples_to_point_cap():
     pane.deleteLater()
     if QtWidgets.QApplication.instance() is app and not app.topLevelWidgets():
         app.quit()
+
+
+def test_plotpane_crosshair_toggle():
+    try:
+        _, _, QtWidgets, _ = get_qt()
+    except ImportError:  # pragma: no cover - environment specific
+        pytest.skip("Qt bindings not available")
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    pane = PlotPane()
+
+    assert pane.is_crosshair_visible()
+
+    pane.set_crosshair_visible(False)
+    assert not pane.is_crosshair_visible()
+
+    pane.set_crosshair_visible(True)
+    assert pane.is_crosshair_visible()
+
+    pane.deleteLater()
+    if QtWidgets.QApplication.instance() is app and not app.topLevelWidgets():
+        app.quit()


### PR DESCRIPTION
## Summary
- add a user-facing plot tools guide covering pan/zoom gestures, legend management, and LOD behaviour
- expose a Reset Plot menu action and connect the toolbar cursor toggle to the plot pane
- extend the plot tests to exercise the crosshair visibility API and link new docs from existing guides

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68eee0725050832988b2c6b757df10bb