### PR TITLE
docs: expand importing guide with provenance appendix

### DIFF
--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,11 @@
 # Patch Notes
 
+## 2025-10-15 (Importing Guide Provenance Appendix) (9:10 am)
+
+- Expanded `docs/user/importing.md` with a provenance export appendix covering the structure of the manifest bundle.
+- Clarified that exported directories include canonical CSVs, original sources, and a chronological log for audit trails.
+- Highlighted unit round-trip safety when sharing exported spectra with collaborators.
+
 ## 2025-10-14 (Plot Interaction Guide) (8:45 pm)
 
 - Added `docs/user/plot_tools.md` covering pan/zoom gestures, crosshair usage, legend management, and the 120k-point LOD cap.

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -38,7 +38,7 @@
 - [x] Draft user quickstart walkthrough covering launch → ingest → unit toggle → export.
 - [x] Author units & conversions reference with idempotency callouts (`docs/user/units_reference.md`).
 - [x] Document plot interaction tools and LOD expectations (`docs/user/plot_tools.md`).
-- [ ] Expand importing guide with provenance export appendix.
+- [x] Expand importing guide with provenance export appendix.
 
 ## Batch 3 QA Log
 

--- a/docs/user/importing.md
+++ b/docs/user/importing.md
@@ -29,6 +29,27 @@ Imported spectra always appear in canonical units inside the application. Use
  underlying data. The raw source file remains untouched in the provenance
  bundle created during export.
 
+## Appendix — Provenance export bundle
+
+Every export initiated from **File → Export Manifest** writes a timestamped
+directory that preserves both the processed spectrum and its origin story. The
+bundle contains:
+
+- `manifest.json` — human-readable metadata describing the session, import
+  source, applied unit conversions, and any math operations performed.
+- `spectra/` — canonicalised arrays in CSV format (`wavelength_nm`,
+  `intensity`) for each trace present in the workspace at export time.
+- `sources/` — verbatim copies of the original uploads alongside their SHA256
+  hashes so you can independently verify integrity.
+- `log.txt` — a chronological history of ingest, analysis, and export actions
+  captured by the provenance service.
+
+Because the manifest records the units detected during import, round-tripping
+through Ångström, micrometre, or wavenumber views does not alter the stored
+values. When sharing data with collaborators, distribute the entire export
+folder so downstream users can inspect both the canonicalised spectra and the
+raw files referenced in the manifest.
+
 ## Quick smoke workflow
 
 Run File → Open on `samples/sample_spectrum.csv`, toggle the units toolbar to Ångström/Transmittance, and export a manifest via File → Export Manifest. This mirrors the automated regression in `tests/test_smoke_workflow.py`, ensuring the ingest pipeline and provenance export are healthy.


### PR DESCRIPTION
## Summary
- add a provenance export appendix to the importing guide describing bundle contents and unit safety
- document the update in patch notes and mark the workplan item complete

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eee4a26e84832989f327f8a0371eb6