### PR TITLE
Clarify JWST reference build manifest instructions

### DIFF
--- a/docs/dev/reference_build.md
+++ b/docs/dev/reference_build.md
@@ -68,6 +68,15 @@ Arguments:
 - `--cache-dir`: where downloaded FITS products are stored.
 - `--output`: destination JSON path.
 
+Start by copying the template manifest to a working file that you can edit without clobbering the documented scaffold:
+
+```bash
+cp tools/reference_build/jwst_targets_template.json tools/reference_build/jwst_targets_manifest.json
+```
+
+Update the copy with the MAST product URIs, metadata, and any additional targets you plan to harvest, then supply the
+new manifest path as the positional `config` argument when invoking the builder.
+
 The script downloads each calibrated product via `astroquery.mast.Observations.download_file`, performs an
 index-based resampling to `bins` points, and writes the final JSON bundle. Each entry receives a `provenance` block with
 `mast_product_uri`, `pipeline_version`, and retrieval timestamp. Downstream UI components render these fields so users can

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -120,6 +120,7 @@
 - [ ] Wire Doppler/pressure/Stark broadening models into the overlay service using the placeholder parameter scaffolding.
 - [ ] Replace digitised JWST tables with calibrated FITS ingestion and provenance links once the pipeline module is ready.
 - [ ] Harvest remaining JWST quick-look targets (WASP-96 b, Mars, Neptune, HD 84406) — Jupiter NIRSpec IFU + MIRI MRS
-      completed 2025-10-15 via Program 1022 download_file workaround.
+      completed 2025-10-15 via Program 1022 download_file workaround. See the
+      [JWST quick-look regeneration notes](../dev/reference_build.md#jwst-quick-look-spectra) for the manifest workflow.
 - [ ] Expand the spectral line catalogue beyond hydrogen (e.g. He I, O III, Fe II) with citations and regression coverage.
 - [ ] Integrate IR functional group heuristics into importer header parsing for automated axis validation.


### PR DESCRIPTION
## Summary
- document copying the JWST targets template before invoking the build helper
- link the batch 10 workplan item to the detailed JWST regeneration instructions

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ef3732423883299fc27b9886e48b64