### PR TITLE
Guard documentation logging initialization and accept superscript wavenumber unit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,9 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         ]
         self._palette_index = 0
 
+        self.log_view: QtWidgets.QPlainTextEdit | None = None
+        self._log_buffer: list[tuple[str, str]] = []
+
         self._setup_ui()
         self._setup_menu()
         self._wire_shortcuts()
@@ -165,7 +168,10 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.log_dock.setWidget(self.log_view)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.BottomDockWidgetArea, self.log_dock)
 
-        self._load_documentation_index()
+        if self._log_buffer:
+            for channel, message in self._log_buffer:
+                self.log_view.appendPlainText(f"[{channel}] {message}")
+            self._log_buffer.clear()
 
         self._build_plot_toolbar()
 
@@ -176,6 +182,8 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
                 f"x={x:.4g} {self.plot_unit()} | y={y:.4g}"
             )
         )
+
+        self._load_documentation_index()
 
     def _build_inspector_tabs(self) -> None:
         # Info tab -----------------------------------------------------
@@ -1194,6 +1202,9 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self._log("Smoothing", f"Mode set to {value}")
 
     def _log(self, channel: str, message: str) -> None:
+        if self.log_view is None:
+            self._log_buffer.append((channel, message))
+            return
         self.log_view.appendPlainText(f"[{channel}] {message}")
 
 

--- a/app/services/units_service.py
+++ b/app/services/units_service.py
@@ -142,6 +142,7 @@ class UnitsService:
             "angstrom": "angstrom",
             "ångström": "angstrom",
             "å": "angstrom",
+            "cm⁻¹": "cm^-1",
         }
         return mappings.get(u, u)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -28,6 +28,16 @@ def test_wavenumber_round_trip():
     assert np.allclose(view_x, x)
 
 
+def test_superscript_wavenumber_round_trip():
+    service = UnitsService()
+    x = np.array([1500.0, 750.0])
+    y = np.array([0.3, 0.7])
+    canonical_x, canonical_y, _ = service.to_canonical(x, y, 'cm⁻¹', 'absorbance')
+    spectrum = Spectrum.create('wavenumber_superscript', canonical_x, canonical_y)
+    view_x, _, _ = service.convert(spectrum, 'cm⁻¹', 'absorbance')
+    assert np.allclose(view_x, x)
+
+
 def test_transmittance_conversion_and_round_trip():
     service = UnitsService()
     x = np.array([400.0])


### PR DESCRIPTION
## Summary
- defer documentation index loading until after the log dock is ready and buffer log messages while the UI initializes
- normalise the superscript wavenumber option advertised in the toolbar so it converts like other wavenumber spellings
- add a regression unit test covering conversions with the superscript wavenumber unit

## Testing
- pytest tests/test_units.py::test_superscript_wavenumber_round_trip -q

------
https://chatgpt.com/codex/tasks/task_e_68efa694ef808329972111d6d09fd849