### PR TITLE
Handle Unicode wavenumber units in UnitsService

### DIFF
--- a/app/services/units_service.py
+++ b/app/services/units_service.py
@@ -134,6 +134,30 @@ class UnitsService:
 
     def _normalise_x_unit(self, unit: str) -> str:
         u = unit.strip().lower()
+
+        # Normalise Unicode minus/superscript characters that commonly appear in
+        # wavenumber annotations (e.g. ``cm⁻¹``) so they map onto the ASCII token
+        # handled by the conversion logic.
+        for minus_variant in ("⁻", "−", "﹣", "－", "–", "—"):
+            u = u.replace(minus_variant, "-")
+        superscript_digits = {
+            "⁰": "0",
+            "¹": "1",
+            "²": "2",
+            "³": "3",
+            "⁴": "4",
+            "⁵": "5",
+            "⁶": "6",
+            "⁷": "7",
+            "⁸": "8",
+            "⁹": "9",
+        }
+        for superscript, digit in superscript_digits.items():
+            u = u.replace(superscript, digit)
+        u = u.replace(" ", "")
+        if u == "cm-1":
+            u = "cm^-1"
+
         mappings = {
             "nanometre": "nm",
             "nanometer": "nm",

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -38,6 +38,15 @@ def test_superscript_wavenumber_round_trip():
     assert np.allclose(view_x, x)
 
 
+def test_from_canonical_handles_superscript_wavenumber():
+    service = UnitsService()
+    x_nm = np.array([5000.0, 10000.0])
+    y = np.array([0.1, 0.2])
+    view_x, view_y = service.from_canonical(x_nm, y, 'cm⁻¹', 'absorbance')
+    assert np.allclose(view_x, np.array([2000.0, 1000.0]))
+    assert np.allclose(view_y, y)
+
+
 def test_transmittance_conversion_and_round_trip():
     service = UnitsService()
     x = np.array([400.0])


### PR DESCRIPTION
## Summary
- normalise Unicode minus and superscript characters so cm⁻¹-style labels map to the canonical cm^-1 token
- add regression coverage to ensure from_canonical handles cm⁻¹ without raising

## Testing
- `pytest tests/test_units.py -k superscript -q`
- `python - <<'PY'
import numpy as np
from app.services.units_service import UnitsService
from app.services.overlay_service import OverlayService
from app.services.spectrum import Spectrum

units = UnitsService()
overlay = OverlayService(units)

spec = Spectrum.create('demo', np.array([5000.0, 10000.0]), np.array([0.2, 0.4]))
overlay.add(spec)
views = overlay.overlay([spec.id], 'cm⁻¹', 'absorbance')
print(views[0]['x'])
print(views[0]['y'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68efa8b2e960832999749c5c756aff23