### PR TITLE
Guard logging before dock ready and add documentation smoke test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
 
         self.log_view: QtWidgets.QPlainTextEdit | None = None
         self._log_buffer: list[tuple[str, str]] = []
+        self._log_ready = False
 
         self._setup_ui()
         self._setup_menu()
@@ -168,6 +169,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.log_dock.setWidget(self.log_view)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.BottomDockWidgetArea, self.log_dock)
 
+        self._log_ready = True
         if self._log_buffer:
             for channel, message in self._log_buffer:
                 self.log_view.appendPlainText(f"[{channel}] {message}")
@@ -1202,7 +1204,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self._log("Smoothing", f"Mode set to {value}")
 
     def _log(self, channel: str, message: str) -> None:
-        if self.log_view is None:
+        if not self._log_ready or self.log_view is None:
             self._log_buffer.append((channel, message))
             return
         self.log_view.appendPlainText(f"[{channel}] {message}")

--- a/tests/test_smoke_workflow.py
+++ b/tests/test_smoke_workflow.py
@@ -97,3 +97,23 @@ def test_smoke_ingest_toggle_and_export(tmp_path: Path, mini_fits: Path) -> None
     assert str(csv_spec.x[0]) in csv_contents
 
     assert bundle["png_path"].read_bytes() == png_bytes
+
+
+def test_show_documentation_no_attribute_error() -> None:
+    """Opening the documentation view should not raise AttributeError during startup."""
+
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        window.show_documentation()
+        app.processEvents()
+        docs_index = window.inspector_tabs.indexOf(window.tab_docs)
+        assert docs_index != -1
+        assert window.inspector_tabs.currentIndex() == docs_index
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- add a readiness flag so log messages buffer until the dock is fully built
- flush buffered log messages once the log view is ready
- add a smoke test that opens the documentation inspector to guard against regressions

## Testing
- pytest -q tests/test_smoke_workflow.py::test_show_documentation_no_attribute_error

------
https://chatgpt.com/codex/tasks/task_e_68efc65e010483299553c940b3884f43