### PR TITLE
Handle Unicode wavenumber aliases

### DIFF
--- a/app/services/units_service.py
+++ b/app/services/units_service.py
@@ -133,7 +133,38 @@ class UnitsService:
         raise UnitError(f"Unsupported destination x unit: {dst}")
 
     def _normalise_x_unit(self, unit: str) -> str:
-        u = unit.strip().lower()
+        raw = unit.strip().lower().replace(" ", "")
+
+        wavenumber_aliases = {
+            "cm^-1",
+            "cm-1",
+            "cm^−1",
+            "cm^–1",
+            "cm^﹣1",
+            "cm^－1",
+            "cm^⁻1",
+            "cm−1",
+            "cm–1",
+            "cm﹣1",
+            "cm－1",
+            "cm⁻1",
+            "cm^-¹",
+            "cm^−¹",
+            "cm^–¹",
+            "cm^﹣¹",
+            "cm^－¹",
+            "cm^⁻¹",
+            "cm-¹",
+            "cm−¹",
+            "cm–¹",
+            "cm﹣¹",
+            "cm－¹",
+            "cm⁻¹",
+        }
+        if raw in wavenumber_aliases:
+            return "cm^-1"
+
+        u = raw
 
         # Normalise Unicode minus/superscript characters that commonly appear in
         # wavenumber annotations (e.g. ``cm⁻¹``) so they map onto the ASCII token
@@ -154,7 +185,6 @@ class UnitsService:
         }
         for superscript, digit in superscript_digits.items():
             u = u.replace(superscript, digit)
-        u = u.replace(" ", "")
         if u == "cm-1":
             u = "cm^-1"
 
@@ -166,7 +196,6 @@ class UnitsService:
             "angstrom": "angstrom",
             "ångström": "angstrom",
             "å": "angstrom",
-            "cm⁻¹": "cm^-1",
         }
         return mappings.get(u, u)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -47,6 +47,24 @@ def test_from_canonical_handles_superscript_wavenumber():
     assert np.allclose(view_y, y)
 
 
+@pytest.mark.parametrize(
+    "unicode_unit",
+    [
+        "cm⁻¹",  # superscript minus and digit
+        "cm^−1",  # Unicode minus following ASCII caret
+        "cm−¹",  # minus sign, superscript digit
+    ],
+)
+def test_from_canonical_accepts_unicode_wavenumber_variants(unicode_unit: str):
+    service = UnitsService()
+    x_nm = np.array([5000.0, 10000.0])
+    expected = np.array([2000.0, 1000.0])
+
+    wavenumber, _ = service.from_canonical(x_nm, np.array([0.1, 0.2]), unicode_unit, 'absorbance')
+
+    assert np.allclose(wavenumber, expected)
+
+
 def test_transmittance_conversion_and_round_trip():
     service = UnitsService()
     x = np.array([400.0])


### PR DESCRIPTION
## Summary
- normalise wavenumber labels that include Unicode minus and superscript digits to the existing cm^-1 alias
- add coverage to ensure from_canonical handles Unicode wavenumber variants

## Testing
- pytest tests/test_units.py -k unicode

------
https://chatgpt.com/codex/tasks/task_e_68efcc4137708329935b49a085a50eab