### PR TITLE
Ensure docs auto-load after log view initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -180,6 +180,9 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
                 self.log_view.appendPlainText(f"[{channel}] {message}")
             self._log_buffer.clear()
 
+        # Ensure documentation auto-load happens only after the log view exists
+        self._load_documentation_index()
+
         self._build_plot_toolbar()
 
         self.status_bar = self.statusBar()
@@ -189,8 +192,6 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
                 f"x={x:.4g} {self.plot_unit()} | y={y:.4g}"
             )
         )
-
-        self._load_documentation_index()
 
     def _build_inspector_tabs(self) -> None:
         # Info tab -----------------------------------------------------

--- a/tests/test_smoke_workflow.py
+++ b/tests/test_smoke_workflow.py
@@ -41,9 +41,10 @@ def test_smoke_ingest_toggle_and_export(tmp_path: Path, mini_fits: Path) -> None
         assert window.windowTitle().startswith("Spectra")
         docs_tab_index = window.inspector_tabs.indexOf(window.tab_docs)
         assert docs_tab_index != -1
+        window.inspector_tabs.setCurrentIndex(docs_tab_index)
+        app.processEvents()
         if window.docs_list.count():
-            window.docs_list.setCurrentRow(0)
-            app.processEvents()
+            assert window.docs_list.currentRow() == 0
             assert window.doc_viewer.toPlainText().strip()
 
         reference_index = window.inspector_tabs.indexOf(window.tab_reference)


### PR DESCRIPTION
## Summary
- load the documentation index after the log pane is constructed to avoid early log writes
- update the smoke workflow test to open the docs tab and rely on the automatic document selection

## Testing
- pytest tests/test_smoke_workflow.py::test_smoke_ingest_toggle_and_export -q

------
https://chatgpt.com/codex/tasks/task_e_68efd6f164d4832983b4e93dad315e62