### PR TITLE
Normalize Unicode wavenumber units

### DIFF
--- a/app/services/units_service.py
+++ b/app/services/units_service.py
@@ -135,56 +135,31 @@ class UnitsService:
     def _normalise_x_unit(self, unit: str) -> str:
         raw = unit.strip().lower().replace(" ", "")
 
-        wavenumber_aliases = {
-            "cm^-1",
-            "cm-1",
-            "cm^−1",
-            "cm^–1",
-            "cm^﹣1",
-            "cm^－1",
-            "cm^⁻1",
-            "cm−1",
-            "cm–1",
-            "cm﹣1",
-            "cm－1",
-            "cm⁻1",
-            "cm^-¹",
-            "cm^−¹",
-            "cm^–¹",
-            "cm^﹣¹",
-            "cm^－¹",
-            "cm^⁻¹",
-            "cm-¹",
-            "cm−¹",
-            "cm–¹",
-            "cm﹣¹",
-            "cm－¹",
-            "cm⁻¹",
-        }
-        if raw in wavenumber_aliases:
+        translation_table = str.maketrans(
+            {
+                "⁻": "-",
+                "−": "-",
+                "﹣": "-",
+                "－": "-",
+                "–": "-",
+                "—": "-",
+                "⁰": "0",
+                "¹": "1",
+                "²": "2",
+                "³": "3",
+                "⁴": "4",
+                "⁵": "5",
+                "⁶": "6",
+                "⁷": "7",
+                "⁸": "8",
+                "⁹": "9",
+            }
+        )
+        u = raw.translate(translation_table)
+
+        if u in {"cm^-1", "1/cm", "wavenumber"}:
             return "cm^-1"
 
-        u = raw
-
-        # Normalise Unicode minus/superscript characters that commonly appear in
-        # wavenumber annotations (e.g. ``cm⁻¹``) so they map onto the ASCII token
-        # handled by the conversion logic.
-        for minus_variant in ("⁻", "−", "﹣", "－", "–", "—"):
-            u = u.replace(minus_variant, "-")
-        superscript_digits = {
-            "⁰": "0",
-            "¹": "1",
-            "²": "2",
-            "³": "3",
-            "⁴": "4",
-            "⁵": "5",
-            "⁶": "6",
-            "⁷": "7",
-            "⁸": "8",
-            "⁹": "9",
-        }
-        for superscript, digit in superscript_digits.items():
-            u = u.replace(superscript, digit)
         if u == "cm-1":
             u = "cm^-1"
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -47,6 +47,17 @@ def test_from_canonical_handles_superscript_wavenumber():
     assert np.allclose(view_y, y)
 
 
+def test_from_canonical_returns_finite_wavenumbers_for_unicode_minus():
+    service = UnitsService()
+    x_nm = np.array([5000.0, 10000.0])
+    y = np.array([0.1, 0.2])
+
+    wavenumber, _ = service.from_canonical(x_nm, y, 'cm⁻¹', 'absorbance')
+
+    assert np.all(np.isfinite(wavenumber))
+    assert np.allclose(wavenumber, np.array([2000.0, 1000.0]))
+
+
 @pytest.mark.parametrize(
     "unicode_unit",
     [


### PR DESCRIPTION
## Summary
- normalize Unicode minus and superscript digits when interpreting wavelength units so variants map to cm^-1
- add a regression test ensuring from_canonical accepts cm⁻¹ and returns finite wavenumbers

## Testing
- pytest tests/test_units.py::test_from_canonical_returns_finite_wavenumbers_for_unicode_minus

------
https://chatgpt.com/codex/tasks/task_e_68efd7e1fb2c8329bcd1b8731ab4bee6