### PR TITLE
Normalize Unicode wavenumber units

### DIFF
--- a/app/services/units_service.py
+++ b/app/services/units_service.py
@@ -12,6 +12,7 @@ numerical drift and the original data is never mutated.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import Dict, Any, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -157,11 +158,11 @@ class UnitsService:
         )
         u = raw.translate(translation_table)
 
-        if u in {"cm^-1", "1/cm", "wavenumber"}:
+        if re.fullmatch(r"cm\^?-1", u) or re.fullmatch(r"cm\^\(-1\)", u):
             return "cm^-1"
 
-        if u == "cm-1":
-            u = "cm^-1"
+        if u in {"1/cm", "wavenumber"}:
+            return "cm^-1"
 
         mappings = {
             "nanometre": "nm",

--- a/tests/test_units_service.py
+++ b/tests/test_units_service.py
@@ -1,0 +1,20 @@
+"""Targeted tests for :mod:`app.services.units_service`."""
+
+import numpy as np
+
+from app.services.units_service import UnitsService
+
+
+def test_from_canonical_wavenumber_accepts_superscript_minus():
+    """Ensure Unicode minus wavenumbers normalise to ``cm^-1``."""
+
+    service = UnitsService()
+    x_nm = np.array([5000.0, 10000.0])
+    y_absorbance = np.array([0.1, 0.2])
+
+    wavenumber, returned_y = service.from_canonical(x_nm, y_absorbance, "cm⁻¹", "absorbance")
+
+    expected = np.array([2000.0, 1000.0])
+    assert np.all(np.isfinite(wavenumber))
+    assert np.allclose(wavenumber, expected)
+    assert np.allclose(returned_y, y_absorbance)


### PR DESCRIPTION
## Summary
- normalise wavenumber spellings with superscript minus to ``cm^-1`` before conversion
- add a regression test ensuring ``UnitsService.from_canonical`` returns finite wavenumbers for ``cm⁻¹``

## Testing
- pytest tests/test_units_service.py

------
https://chatgpt.com/codex/tasks/task_e_68efd9b5eec48329a1530eed34fa17a5