### PR TITLE
Ensure documentation auto-load waits for log view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -180,9 +180,6 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
                 self.log_view.appendPlainText(f"[{channel}] {message}")
             self._log_buffer.clear()
 
-        # Ensure documentation auto-load happens only after the log view exists
-        self._load_documentation_index()
-
         self._build_plot_toolbar()
 
         self.status_bar = self.statusBar()
@@ -192,6 +189,10 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
                 f"x={x:.4g} {self.plot_unit()} | y={y:.4g}"
             )
         )
+
+        # Load documentation entries after all dock widgets (including the log view)
+        # have been initialised so that the initial selection can log status safely.
+        self._load_documentation_index()
 
     def _build_inspector_tabs(self) -> None:
         # Info tab -----------------------------------------------------

--- a/tests/test_smoke_workflow.py
+++ b/tests/test_smoke_workflow.py
@@ -164,3 +164,27 @@ def test_show_documentation_no_attribute_error() -> None:
         window.close()
         window.deleteLater()
         app.processEvents()
+
+
+def test_docs_tab_auto_loads_first_entry_without_error() -> None:
+    """Switching to the Docs tab should auto-load the first entry without exploding."""
+
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        docs_index = window.inspector_tabs.indexOf(window.tab_docs)
+        assert docs_index != -1
+        window.inspector_tabs.setCurrentIndex(docs_index)
+        app.processEvents()
+
+        if window.docs_list.count():
+            # The first entry should be selected automatically and rendered without error.
+            assert window.docs_list.currentRow() == 0
+            assert window.doc_viewer.toPlainText().strip()
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- ensure the documentation index loads only after the log dock is fully initialised
- add a smoke regression test that switches to the Docs tab and verifies the first entry auto-loads without errors

## Testing
- pytest tests/test_smoke_workflow.py -k docs -q

------
https://chatgpt.com/codex/tasks/task_e_68efd99c715c83299e2f88ba13cd0d64