### PR TITLE
Update reference preview layout and verify overlay behaviour

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -796,14 +796,6 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         controls.addWidget(self.reference_overlay_toggle)
         controls.addStretch(1)
 
-        self.reference_plot = pg.PlotWidget()
-        self.reference_plot.setObjectName("reference-preview")
-        self.reference_plot.setMinimumHeight(220)
-        self.reference_plot.showGrid(x=True, y=False, alpha=0.15)
-        self.reference_plot.setLabel("bottom", "Wavelength", units=self.plot_unit())
-        self.reference_plot.setLabel("left", "Normalised amplitude")
-        layout.addWidget(self.reference_plot, 1)
-
         self.reference_table = QtWidgets.QTableWidget()
         self.reference_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
         self.reference_table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
@@ -811,6 +803,14 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         header = self.reference_table.horizontalHeader()
         header.setStretchLastSection(True)
         layout.addWidget(self.reference_table, 1)
+
+        self.reference_plot = pg.PlotWidget()
+        self.reference_plot.setObjectName("reference-preview")
+        self.reference_plot.setMinimumHeight(220)
+        self.reference_plot.showGrid(x=True, y=False, alpha=0.15)
+        self.reference_plot.setLabel("bottom", "Wavelength", units=self.plot_unit())
+        self.reference_plot.setLabel("left", "Normalised amplitude")
+        layout.addWidget(self.reference_plot, 1)
 
         self.reference_meta = QtWidgets.QTextBrowser()
         self.reference_meta.setOpenExternalLinks(True)

--- a/docs/user/reference_data.md
+++ b/docs/user/reference_data.md
@@ -7,9 +7,9 @@ authoritative NIST assets from digitised JWST placeholders that still need regen
 
 ## Plot previews and overlays
 
-- The tab now embeds an interactive **pyqtgraph** preview above the data table. Hydrogen datasets draw vertical markers
-  at the stored wavelengths, infrared groups render shaded spans for each wavenumber window, and JWST targets plot a
-  line with error bars when uncertainties are present.
+- The tab now embeds an interactive **pyqtgraph** preview beneath the data table. Hydrogen datasets draw vertical
+  markers at the stored wavelengths, infrared groups render shaded spans for each wavenumber window, and JWST targets
+  plot a line with error bars when uncertainties are present.
 - Use the **Overlay on main plot** checkbox to project the selected dataset onto the central Plot Pane. Overlays are
   tagged with a deterministic `reference::…` trace ID and a legend label that cites the original units and, for JWST
   targets, the stored resolving power. The preview normalises intensities so the reference trace fits alongside

--- a/tests/test_smoke_workflow.py
+++ b/tests/test_smoke_workflow.py
@@ -79,6 +79,16 @@ def test_smoke_ingest_toggle_and_export(tmp_path: Path, mini_fits: Path) -> None
         assert ir_regions, "Expected shaded regions for IR functional groups"
         assert window._reference_overlay_key in window.plot._traces
 
+        placeholder_index = next(
+            idx
+            for idx in range(window.reference_dataset_combo.count())
+            if window.reference_dataset_combo.itemData(idx)[0] == "line_shapes"
+        )
+        window.reference_dataset_combo.setCurrentIndex(placeholder_index)
+        app.processEvents()
+        assert window.reference_overlay_toggle.isEnabled() is False
+        assert window._reference_overlay_key is None
+
         jwst_index = next(
             idx
             for idx in range(window.reference_dataset_combo.count())


### PR DESCRIPTION
## Summary
- move the inspector reference preview plot beneath the table while keeping overlay wiring intact
- document the preview layout and how reference overlays respect stored unit and resolution metadata
- extend the smoke workflow test to cover placeholder datasets that should not create overlays

## Testing
- pytest tests/test_smoke_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68efd9c229048329b6def024aaa3c821