### PR TITLE
Ensure reference tab builds after toolbar initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -160,6 +160,8 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.dataset_dock.setWidget(self.dataset_tree)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, self.dataset_dock)
 
+        self._build_plot_toolbar()
+
         self.inspector_dock = QtWidgets.QDockWidget("Inspector", self)
         self.inspector_dock.setObjectName("dock-inspector")
         self.inspector_tabs = QtWidgets.QTabWidget()
@@ -179,8 +181,6 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
             for channel, message in self._log_buffer:
                 self.log_view.appendPlainText(f"[{channel}] {message}")
             self._log_buffer.clear()
-
-        self._build_plot_toolbar()
 
         self.status_bar = self.statusBar()
         self.status_bar.showMessage("Ready")

--- a/tests/test_reference_ui.py
+++ b/tests/test_reference_ui.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+try:
+    from app.main import SpectraMainWindow
+    from app.qt_compat import get_qt
+except ImportError as exc:  # pragma: no cover - optional on headless CI
+    SpectraMainWindow = None  # type: ignore[assignment]
+    _qt_import_error = exc
+    QtCore = QtGui = QtWidgets = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised via regression test
+    _qt_import_error = None
+    QtCore, QtGui, QtWidgets, _ = get_qt()
+
+
+def _ensure_app() -> QtWidgets.QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_reference_tab_builds_without_error() -> None:
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    pytest.importorskip("pyqtgraph")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        reference_index = window.inspector_tabs.indexOf(window.tab_reference)
+        assert reference_index != -1
+
+        axis = window.reference_plot.getPlotItem().getAxis("bottom")
+        assert axis is not None
+
+        label_text = ""
+        if hasattr(axis, "labelText"):
+            label_text = axis.labelText
+        elif hasattr(axis, "label"):
+            label = axis.label
+            if hasattr(label, "text"):
+                label_text = label.text
+            elif hasattr(label, "toPlainText"):
+                label_text = label.toPlainText()
+
+        assert label_text
+        assert "Wavelength" in label_text
+        assert window.unit_combo.currentText() in label_text
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- build the plot toolbar before constructing inspector tabs so the reference pane can access the unit selector
- add a regression test to instantiate the main window and verify the reference tab labels render with the toolbar units

## Testing
- pytest tests/test_reference_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68efdbae19e483298db9a4e0b5025e9f