### PR TITLE
Initialize plot toolbar before menu setup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -138,6 +138,10 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.central_split.addWidget(self.plot)
         self.plot.autoscale()
 
+        # Build the plot toolbar immediately so dependent UI (e.g. menus)
+        # can reference it during their own setup routines.
+        self._build_plot_toolbar()
+
         self.data_table = QtWidgets.QTableWidget()
         self.data_table.setColumnCount(4)
         self.data_table.setHorizontalHeaderLabels(["Spectrum", "Point", "X", "Y"])

--- a/tests/test_documentation_ui.py
+++ b/tests/test_documentation_ui.py
@@ -48,3 +48,37 @@ def test_show_documentation_selects_first_entry_without_error() -> None:
         window.close()
         window.deleteLater()
         app.processEvents()
+
+
+def test_plot_toolbar_and_normalization_combo_available() -> None:
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        app.processEvents()
+
+        assert window.plot_toolbar is not None
+        assert window.plot_toolbar.isVisible()
+
+        view_action = next(
+            (action for action in window.menuBar().actions() if action.text() == "&View"),
+            None,
+        )
+        assert view_action is not None
+        view_menu = view_action.menu()
+        assert view_menu is not None
+        assert window.plot_toolbar.toggleViewAction() in view_menu.actions()
+
+        assert window.unit_combo is not None
+        assert window.unit_combo.count() > 0
+
+        assert window.norm_combo is not None
+        assert window.norm_combo.count() > 0
+        assert window.norm_combo.findText("None") != -1
+        assert window.norm_combo.isVisible()
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- build the plot toolbar during UI setup so the View menu can expose its toggle action
- ensure unit and normalization controls are available immediately on launch
- add a Qt regression test covering the toolbar visibility and normalization combo population

## Testing
- pytest tests/test_documentation_ui.py *(skipped: Qt stack unavailable in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f00f63683883298ce9b20191a6af8a