### PR TITLE
Fix duplicate Inspector dock and add regression test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -188,13 +188,6 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.inspector_dock.setWidget(self.inspector_tabs)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.RightDockWidgetArea, self.inspector_dock)
 
-        self.inspector_dock = QtWidgets.QDockWidget("Inspector", self)
-        self.inspector_dock.setObjectName("dock-inspector")
-        self.inspector_tabs = QtWidgets.QTabWidget()
-        self._build_inspector_tabs()
-        self.inspector_dock.setWidget(self.inspector_tabs)
-        self.addDockWidget(QtCore.Qt.DockWidgetArea.RightDockWidgetArea, self.inspector_dock)
-
         self.status_bar = self.statusBar()
         self.status_bar.showMessage("Ready")
         self.plot.pointHovered.connect(

--- a/tests/test_documentation_ui.py
+++ b/tests/test_documentation_ui.py
@@ -82,3 +82,34 @@ def test_plot_toolbar_and_normalization_combo_available() -> None:
         window.close()
         window.deleteLater()
         app.processEvents()
+
+
+def test_single_inspector_dock_created() -> None:
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        app.processEvents()
+
+        inspector_docks = [
+            dock
+            for dock in window.findChildren(QtWidgets.QDockWidget)
+            if dock.objectName() == "dock-inspector"
+        ]
+        assert len(inspector_docks) == 1
+        assert inspector_docks[0] is window.inspector_dock
+
+        view_action = next(
+            (action for action in window.menuBar().actions() if action.text() == "&View"),
+            None,
+        )
+        assert view_action is not None
+        view_menu = view_action.menu()
+        assert view_menu is not None
+        assert window.inspector_dock.toggleViewAction() in view_menu.actions()
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- remove the redundant Inspector dock creation so the main window only instantiates a single dock
- ensure the view menu still references the surviving Inspector dock and add a regression test to enforce the singleton dock

## Testing
- pytest tests/test_documentation_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68f0167898388329ae2d7a89e6c5ad79