### PR TITLE
Replace IR overlay screenshot reference with text guidance

### DIFF
--- a/docs/user/plot_tools.md
+++ b/docs/user/plot_tools.md
@@ -37,6 +37,16 @@ Use the control to adjust every visible trace without mutating the underlying da
 
 The data table and provenance metadata mirror the active normalisation, and the plot toolbar’s left-axis label calls out both the unit (e.g. `%T`) and the selected normalisation mode for downstream auditing.
 
+## Overlay alignment and troubleshooting
+
+Reference overlays adopt the scaling of the active plot so annotations land where you expect them. The IR functional-group lanes, for example, now anchor their filled band to the visible y-axis span and assign each label to its own vertical slot. When you normalise a trace or zoom the view, the overlay recalculates those slots to keep the stacked annotations readable. If labels ever drift out of band after switching datasets:
+
+- Toggle **Overlay on plot** off and back on to rebuild the payload against the new scale.
+- Use **View → Reset Plot** to reapply auto-range—the overlay matches the recomputed intensity span.
+- Confirm no hidden traces define the axis limits; even invisible datasets can contribute to the active span if their visibility checkbox remains enabled.
+
+Automated coverage in `tests/test_reference_ui.py::test_ir_overlay_labels_stack_inside_band` protects the label-spacing logic, so overlap usually signals that the active axis is extremely compressed. Widening the y-range or temporarily disabling normalisation restores the expected layout.
+
 ## Level-of-detail safeguards
 
 High-resolution spectra can contain millions of samples. Rendering every point would make panning and zooming sluggish, so the plot pane automatically enforces a peak-envelope LOD cap:

--- a/docs/user/reference_data.md
+++ b/docs/user/reference_data.md
@@ -24,9 +24,18 @@ authoritative NIST assets from digitised JWST placeholders that still need regen
 - Contents: characteristic absorption windows (cm⁻¹) for O–H, N–H, aliphatic/aromatic C–H, carbonyl variants, alkynes,
   and carboxylates. Each range is annotated with intensity heuristics and vibrational modes.
 - Usage: load **IR Functional Groups**, then filter by mode (“stretch”), functional class (“carbonyl”), or a wavenumber
-  value to shortlist plausible assignments during import QA. Each band now renders as a labelled shaded lane near the top of
-  the preview plot so you can identify which functional class occupies a window before projecting it onto live data. The
-  dataset provenance links back to the staging CSV stored under `docs/reference_sources/`.
+  value to shortlist plausible assignments during import QA. Each band now renders as a labelled shaded lane that locks to the
+  active intensity span, keeping the overlay vertically anchored even after you normalise or zoom. Labels stack inside the lane
+  in discrete slots so you can read overlapping functional classes without dragging them out of band, and the fill realigns with
+  the trace currently defining the y-axis scale. See the
+  [overlay alignment guidance](plot_tools.md#overlay-alignment-and-troubleshooting) for tips on re-synching the lane with
+  exported plots or alternative unit choices.
+- Preview: stacked labels hug the filled band and stay within the active intensity span. Trigger the overlay in-app (or reuse
+  an existing capture from `File → Export → Manifest`) to generate a fresh screenshot once binary assets are permitted again.
+
+- QA note: `tests/test_reference_ui.py::test_ir_overlay_labels_stack_inside_band` exercises the label-spacing safeguard so
+  annotations remain legible when multiple functional groups share the same window. The dataset provenance links back to the
+  staging CSV stored under `docs/reference_sources/`.
 
 ## Line-shape placeholders
 
@@ -57,9 +66,10 @@ pipeline is wired into CI. Each record cites its release page and records the ap
 1. Select a dataset from the combo box; the Reference plot updates immediately without forcing the selection back to the
    first entry, and the metadata pane refreshes with provenance and citation details.
 2. Enable **Overlay on plot** to add the previewed dataset to the main graph. Hydrogen lines respect their relative
-   intensities, IR bands occupy labelled shaded lanes near the top of the axis, and JWST spectra draw as standard curves with
-   optional uncertainty envelopes. Switching the combo box while the overlay toggle is enabled automatically swaps the
-   projected reference so the main plot always mirrors the active dataset.
+   intensities, IR bands anchor to the active intensity span and dynamically stack their labels inside the shaded lane, and JWST
+   spectra draw as standard curves with optional uncertainty envelopes. Switching the combo box while the overlay toggle is
+   enabled automatically swaps the projected reference so the main plot always mirrors the active dataset and keeps the labels
+   aligned with the visible scale.
 3. Use the Inspector filter bar to narrow down to wavelength windows (e.g. enter `1.4` to isolate WASP-96 b’s water
    absorption peak) and click citation links in the metadata pane to open the underlying source documentation.
 4. If the plot toolbar is hidden, use **View → Plot Toolbar** to reveal the unit and normalization controls before deciding


### PR DESCRIPTION
## Summary
- remove the newly added IR overlay screenshot to avoid binary assets in the documentation update
- replace the visual callout with textual guidance that explains how to capture the in-app preview without bundling binaries

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f02b6753508329bed66ca1b4849130