### PR TITLE
docs: note IR overlay anchoring updates

### DIFF
--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,11 @@
 # Patch Notes
 
+## 2025-10-16 (IR overlay anchoring & stacked labels) (11:42 pm UTC)
+
+- Anchored the IR reference overlay to the active dataset so the preview and main canvas stay in lockstep when swapping instruments, consolidating the wiring in [`app/main.py`](../../app/main.py).
+- Stacked overlay labels to avoid collisions when multiple functional-group bands share a region, updating the reference-layer layout logic in [`app/main.py`](../../app/main.py).
+- Extended the regression suite with overlay anchoring and label-order assertions in [`tests/test_reference_ui.py`](../../tests/test_reference_ui.py) to guard the new behaviour.
+
 ## 2025-10-15 (Reference selection + importer layout cache) (8:42 pm UTC)
 
 - Fixed the Reference inspector so combo-box changes always drive the preview plot and overlay payloads, preventing the first dataset from lingering when toggling between hydrogen, IR, and JWST entries.


### PR DESCRIPTION
## Summary
- log the 2025-10-16 patch notes for IR overlay anchoring and stacked labels
- link to the implementation and regression coverage in app/main.py and tests/test_reference_ui.py for traceability

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f034d8d7748329804aa268f2c5a921