### PR TITLE
Summarize 2025-10-15 patch work in knowledge log

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -91,3 +91,158 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
 **Summary**: Authored the first-run quickstart (`docs/user/quickstart.md`) so new operators can launch the desktop build, ingest bundled spectra, validate unit toggles, and export a provenance bundle without guesswork. Updated the README quick start section to highlight the guide and extended the Batch 3 workplan to track remaining documentation gaps aligned with the inventory. Captured the work in patch notes for traceability.
 
 **References**: `docs/user/quickstart.md`, `README.md`, `docs/reviews/workplan.md`, `docs/history/PATCH_NOTES.md`.
+## 2025-10-15 00:17 – Provenance Exports
+
+**Author**: agent
+
+**Context**: Provenance bundle hardening and documentation alignment.
+
+**Summary**: Expanded export bundles to emit per-spectrum CSVs, copy source uploads, and write a structured activity log so downstream reviewers can trace every spectrum back to its canonical and raw forms.【F:app/services/provenance_service.py†L50-L108】 Regression coverage now confirms the manifest, CSVs, PNG snapshot, and log travel together and that canonical/exported paths are reflected inside the manifest for auditing.【F:tests/test_provenance_manifest.py†L24-L74】 Updated the importing guide’s provenance appendix so operators know what to expect in the bundle until the roadmap/workplan refresh lands, at which point I’ll backfill a direct planning link here.【F:docs/user/importing.md†L92-L111】【F:docs/reviews/workplan.md†L81-L85】
+
+**References**: `app/services/provenance_service.py`, `tests/test_provenance_manifest.py`, `docs/user/importing.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 00:37 – Importer Heuristics & In-App Docs
+
+**Author**: agent
+
+**Context**: CSV/TXT heuristic upgrades and embedded documentation viewer.
+
+**Summary**: Reworked the CSV importer to cache header layouts, scan messy tables for the dominant numeric block, and score candidate axes so we can recover wavelength/intensity pairs even when prose, Unicode units, or intensity-first exports get in the way.【F:app/services/importers/csv_importer.py†L93-L200】 Regression tests now cover preface-based unit detection, noisy-column scoring, cache invalidation, and axis corrections to keep heuristics honest.【F:tests/test_csv_importer.py†L11-L160】 Wired a Docs tab into the Inspector (and exposed it via Help → View Documentation) so all user guides render in-app for quick reference; I’ll link the refreshed roadmap/workplan doc when it’s published to capture this dependency there.【F:app/main.py†L1795-L1849】【F:docs/user/in_app_documentation.md†L1-L34】【F:docs/reviews/workplan.md†L87-L99】
+
+**References**: `app/services/importers/csv_importer.py`, `tests/test_csv_importer.py`, `app/main.py`, `docs/user/in_app_documentation.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 01:04 – Normalization Pipeline & Axis Heuristics
+
+**Author**: agent
+
+**Context**: Overlay normalization plumbing and importer profile-based swaps.
+
+**Summary**: Routed overlay rendering through a normalization helper so Max and Area modes scale reference spectra deterministically while keeping raw arrays intact for provenance.【F:app/services/overlay_service.py†L36-L92】 Added a profile-based swap to the CSV importer so monotonic intensity channels no longer masquerade as the independent axis, ensuring the plot toolbar’s normalization toggle manipulates the correct series.【F:app/services/importers/csv_importer.py†L174-L200】 Regression coverage now verifies both normalization paths and importer decisions, and the importing guide documents how raw units stay untouched until operators opt in to scaling; I’ll update this note with a roadmap/workplan link once that artifact is refreshed.【F:tests/test_overlay_service.py†L6-L41】【F:docs/user/importing.md†L34-L90】【F:docs/reviews/workplan.md†L100-L110】
+
+**References**: `app/services/overlay_service.py`, `app/services/importers/csv_importer.py`, `tests/test_overlay_service.py`, `docs/user/importing.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 01:27 – Importer Header Safeguards
+
+**Author**: agent
+
+**Context**: Header-driven unit enforcement and conflict resolution.
+
+**Summary**: Tightened the CSV importer so unit-only headers are trusted, conflicting axis labels trigger a swap with recorded rationale, and layout cache hits are ignored when validation fails, preventing subtle regressions on repeated ingest sessions.【F:app/services/importers/csv_importer.py†L176-L200】 Added regression tests to lock in the swap rationale, unit-only header handling, and cache miss flow, with documentation updates queued in the workplan backlog for follow-up linking once refreshed.【F:tests/test_csv_importer.py†L92-L184】【F:docs/reviews/workplan.md†L111-L123】
+
+**References**: `app/services/importers/csv_importer.py`, `tests/test_csv_importer.py`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 03:24 – Reference Library & JWST Quick-Look Data
+
+**Author**: agent
+
+**Context**: Bundled reference datasets and inspector surfacing.
+
+**Summary**: Staged hydrogen line lists, IR functional groups, line-shape placeholders, and digitised JWST spectra in the ReferenceLibrary so offline users can browse curated datasets with provenance metadata intact.【F:app/services/reference_library.py†L11-L126】 Regression coverage now asserts the catalogues include expected IDs, generators, and JWST quick-look metadata, while the reference guide narrates how overlays behave and calls out the planned swap to calibrated JWST pipelines—will backfill the roadmap/workplan link referencing that migration as soon as it lands.【F:tests/test_reference_library.py†L5-L45】【F:docs/user/reference_data.md†L1-L85】【F:docs/reviews/workplan.md†L150-L155】
+
+**References**: `app/services/reference_library.py`, `tests/test_reference_library.py`, `docs/user/reference_data.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 04:18 – Reference Regeneration Tooling
+
+**Author**: agent
+
+**Context**: Build scripts and provenance scaffolding for reference assets.
+
+**Summary**: Added reproducible build scripts for hydrogen, IR bands, and JWST quick-look spectra so future refreshes capture generator metadata, retrieval timestamps, and pipeline settings inside each JSON asset.【F:tools/reference_build/build_jwst_quicklook.py†L1-L100】【F:docs/dev/reference_build.md†L1-L82】 Updated the reference guide to surface provenance fields in the inspector, noting the pending JWST pipeline replacement that we’ll link to the roadmap/workplan entry once updated.【F:docs/user/reference_data.md†L20-L63】【F:docs/reviews/workplan.md†L139-L148】
+
+**References**: `tools/reference_build/build_jwst_quicklook.py`, `docs/dev/reference_build.md`, `docs/user/reference_data.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 07:05 – Reference Plotting & Multi-Import Workflow
+
+**Author**: agent
+
+**Context**: Inspector plot integration and batch ingest UX.
+
+**Summary**: Ensured the Reference tab renders hydrogen bars, IR bands, and JWST curves inside an embedded plot while enabling File → Open to select multiple spectra in one pass; overlay toggles now mirror the active dataset without desynchronising the preview.【F:app/main.py†L900-L1040】 The smoke workflow regression covers the end-to-end path—instantiating the docs tab, plotting reference datasets, toggling overlays, and exporting manifests—which we’ll tie back to refreshed planning docs when available.【F:tests/test_smoke_workflow.py†L30-L142】【F:docs/reviews/workplan.md†L155-L160】
+
+**References**: `app/main.py`, `tests/test_smoke_workflow.py`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 07:18 – Reference Overlay Fixes
+
+**Author**: agent
+
+**Context**: Overlay toggle persistence and documentation updates.
+
+**Summary**: Patched the Reference inspector so combo-box selections stick, JWST datasets draw their sampled spectra, and overlay toggles follow the active dataset rather than the first entry, keeping the main plot and preview in sync.【F:app/main.py†L953-L1074】 Updated the reference guide to explain the synchronized overlay workflow and queued doc screenshot refreshes in the workplan backlog—link to be backfilled post-update.【F:docs/user/reference_data.md†L64-L77】【F:docs/reviews/workplan.md†L10-L14】
+
+**References**: `app/main.py`, `docs/user/reference_data.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 07:45 – Reference Plotting & Importer Profile Swap
+
+**Author**: agent
+
+**Context**: Session persistence for reference selection and importer safeguards.
+
+**Summary**: Persisted reference combo selections across sessions so JWST targets and IR overlays stay active after restarts while bolstering the importer’s profile-based safeguards that prevent jittery axes from being overwritten by monotonic intensity exports.【F:app/main.py†L961-L1040】【F:app/services/importers/csv_importer.py†L193-L200】 Regression coverage keeps combo changes, overlay payload swaps, and importer rationale in check; roadmap/workplan link will be backfilled once refreshed.【F:tests/test_smoke_workflow.py†L72-L96】【F:tests/test_csv_importer.py†L66-L133】【F:docs/reviews/workplan.md†L24-L32】
+
+**References**: `app/main.py`, `app/services/importers/csv_importer.py`, `tests/test_smoke_workflow.py`, `tests/test_csv_importer.py`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 08:18 – Raw Intensity Defaults & Overlay Label Stacking
+
+**Author**: agent
+
+**Context**: Plot unit defaults and IR overlay readability.
+
+**Summary**: Restored plot traces to display their source intensity units by default so `%T`, absorbance, and transmittance series remain untouched until operators choose normalization, with the plot pane wiring conversions accordingly.【F:app/ui/plot_pane.py†L258-L303】 Tightened overlay application so IR bands reuse the active dataset payload and stack labels within the band bounds, preventing collisions when multiple functional groups align.【F:app/main.py†L1496-L1686】 Tests assert raw unit preservation and stacked label spacing; the reference guide highlights the behaviour while awaiting updated roadmap/workplan links for documentation follow-ups.【F:tests/test_smoke_workflow.py†L144-L164】【F:tests/test_reference_ui.py†L62-L139】【F:docs/user/reference_data.md†L26-L37】【F:docs/reviews/workplan.md†L4-L8】
+
+**References**: `app/ui/plot_pane.py`, `app/main.py`, `tests/test_smoke_workflow.py`, `tests/test_reference_ui.py`, `docs/user/reference_data.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 08:42 – Reference Selection & Importer Layout Cache
+
+**Author**: agent
+
+**Context**: Reference inspector state management and importer caching.
+
+**Summary**: Fixed the Reference inspector so combo changes drive both the preview plot and overlay payloads, eliminating stale datasets when switching between hydrogen, IR, and JWST entries.【F:app/main.py†L953-L1074】 Added a session layout cache to the CSV importer so previously classified header arrangements reuse their confirmed column order while still validating cache hits before applying them.【F:app/services/importers/csv_importer.py†L163-L185】 Regression coverage locks in cache behaviour and overlay anchoring; roadmap/workplan linkage will be filled in once the updated planning doc lands.【F:tests/test_csv_importer.py†L92-L134】【F:tests/test_reference_ui.py†L90-L200】【F:docs/reviews/workplan.md†L6-L9】
+
+**References**: `app/main.py`, `app/services/importers/csv_importer.py`, `tests/test_csv_importer.py`, `tests/test_reference_ui.py`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 09:10 – Importing Guide Provenance Appendix
+
+**Author**: agent
+
+**Context**: User documentation for export bundles.
+
+**Summary**: Expanded the importing guide with a provenance export appendix that walks through manifest contents, canonical CSVs, copied sources, and log expectations, reinforcing the bundle hardening captured earlier.【F:docs/user/importing.md†L92-L111】 Will backfill direct roadmap/workplan links to this documentation sprint once the refreshed planning artifacts are available.【F:docs/reviews/workplan.md†L11-L14】
+
+**References**: `docs/user/importing.md`, `docs/reviews/workplan.md`.
+
+---
+
+## 2025-10-15 18:45 – Reference Overlay Crash Fixes
+
+**Author**: agent
+
+**Context**: Startup stability and overlay resilience.
+
+**Summary**: Deferred unit toolbar initialization and hardened overlay refresh logic so the Reference tab no longer crashes during startup, handles Unicode wavenumber tokens, and keeps the main plot responsive while default samples load.【F:app/main.py†L144-L156】【F:app/main.py†L1496-L1551】 The smoke test exercises launch plus overlay toggles to confirm clean startup; I’ll append roadmap/workplan links documenting this stabilization once those updates are published.【F:tests/test_smoke_workflow.py†L30-L101】【F:docs/reviews/workplan.md†L6-L9】
+
+**References**: `app/main.py`, `tests/test_smoke_workflow.py`, `docs/reviews/workplan.md`.
+
+---


### PR DESCRIPTION
## Summary
- add chronological knowledge log entries for every 2025-10-15 patch batch, covering rationale, outcomes, and pending follow-ups
- cross-reference the relevant modules, tests, and docs cited in the patch notes and note planned roadmap/workplan backfills

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f03dc796908329ad6d921421165835