### PR TITLE
Clarify importer docs and link to GUI filter roadmap

### DIFF
--- a/docs/dev/ingest_pipeline.md
+++ b/docs/dev/ingest_pipeline.md
@@ -6,12 +6,18 @@
       └──────────────┘      │  (CSV/FITS/   │      │ to canonical nm  │
                             │   JCAMP)      │      │ + absorbance     │
                             └───────────────┘      └──────────────────┘
-                                     │                         │
-                                     ▼                         ▼
-                               ┌────────────┐         ┌──────────────────┐
-                               │ Spectrum   │ <------ │ Provenance entry │
-                               │ (canonical │         │ + LocalStore     │
-                               │   nm/A10)  │         └──────────────────┘
+                                     │
+                                     ▼
+                               ┌────────────┐
+                               │ Spectrum   │
+                               │ (canonical │
+                               │   nm/A10)  │
+                               └────────────┘
+                                     │
+                                     ▼
+                               ┌──────────────────┐
+                               │ Provenance entry │
+                               └──────────────────┘
 ```
 
 - Every importer reports the source units. The `UnitsService` normalises the
@@ -21,11 +27,14 @@
 - The resulting `Spectrum` is immutable. Derived views use unit conversions at
   display time, so toggling units is idempotent and never mutates the stored
   arrays.
-- The `LocalStore` copies the raw file to `%APPDATA%/SpectraApp/data` (or the
-  platform equivalent) and records a `sha256` checksum alongside unit metadata.
-  This makes repeat loads instantaneous and ensures provenance is reproducible.
 - Provenance exports call `ProvenanceService.export_bundle`, which writes a
   manifest, a canonical CSV snapshot, and a PNG plot into the selected folder.
+
+> **Next steps**: Integrate the `LocalStore` cache so imported files are copied
+> into the managed data directory with SHA256 deduplication. This is tracked in
+> the [GUI filter expansion roadmap
+> entry](../../reports/roadmap.md#gui-file-dialog-filter-expansion), which also
+> covers expanding the File → Open filters beyond CSV/TXT.
 
 ## Smoke validation
 

--- a/docs/user/importing.md
+++ b/docs/user/importing.md
@@ -1,8 +1,12 @@
 # Importing Local Spectra
 
-The Import dialog accepts comma-separated text, JCAMP-DX, and FITS spectra. All
-files are normalised into the app's canonical wavelength baseline of
-nanometres while preserving the raw arrays on disk for provenance.
+The **File → Open** picker currently filters to comma-separated (`*.csv`,
+`*.txt`) datasets. JCAMP-DX still appears once you toggle the OS-provided
+"*All files*" view, but FITS ingest requires manually typing or pasting the path
+into the filename field until the [GUI filter expansion roadmap
+item](../../reports/roadmap.md#gui-file-dialog-filter-expansion) lands. Imported
+arrays are normalised into the app's canonical wavelength baseline of
+nanometres while preserving the raw data on disk for provenance.
 
 ## Supported formats
 
@@ -13,18 +17,22 @@ nanometres while preserving the raw arrays on disk for provenance.
 - **FITS** – 1D binary tables with wavelength and flux columns. The importer
   looks for standard names such as `WAVELENGTH`, `WAVE`, or `FLUX`. Original
   header metadata is preserved in the provenance panel. Install the optional
-  `astropy` dependency to enable FITS ingest on new machines; without it the
-  menu item remains but attempting to load FITS files will raise a helpful
-  error.
+  `astropy` dependency (`pip install astropy`) to enable FITS ingest on new
+  machines; without it the menu item remains but attempting to load FITS files
+  will raise a helpful error.
 - **JCAMP-DX** – Compact infrared/UV spectral files using `##XYDATA` blocks.
 
 ## How to import
 
 1. Choose **File → Open** and select one or more spectra (hold `Ctrl` or `Shift` to pick multiple files in a single pass).
 2. Review the detected units shown in the preview banner.
-3. Confirm the ingest. The data is copied into the local cache (see
-   `docs/dev/ingest_pipeline.md`) so that reloading the same file is
-   instantaneous.
+3. Confirm the ingest. The spectrum is normalised in-memory; LocalStore-based
+   caching is planned but not yet wired into the desktop build.
+
+> **Planned enhancement**: The `LocalStore` cache integration will copy the raw
+> upload alongside the canonical arrays so repeat loads avoid re-parsing. Track
+> progress via the [GUI filter expansion roadmap
+> entry](../../reports/roadmap.md#gui-file-dialog-filter-expansion).
 
 Imported spectra always appear in canonical units inside the application. Use
  the unit toggle on the toolbar to view alternative axes without mutating the

--- a/reports/roadmap.md
+++ b/reports/roadmap.md
@@ -38,6 +38,9 @@ checkboxes in [Batch 13](../docs/reviews/workplan.md#workplan--batch-13-2025-10-
   traceability for release sign-off.
 - **Overlay polish and accessibility.** Tighten legend callouts, tooltip contrast, and screenshot updates across the user guides
   to reflect the refreshed PySide6 layout. This encompasses the documentation refresh tasks in Batch 13 and feeds future QA runs.
+- **GUI file dialog filter expansion.** Broaden the **File → Open** picker so it recognises FITS and JCAMP-DX assets without
+  manual path entry, and expose an affordance for typing absolute paths. Track optional dependencies (e.g., `astropy`) and align
+  importer hints once the LocalStore-backed caching lands.
 - **Qt-enabled CI guidance.** Draft the documented recipe (or CI configuration) for running the Qt-dependent UI tests without
   skips, improving confidence before the next release candidate.
 


### PR DESCRIPTION
## Summary
- document current File → Open filtering limits, optional astropy dependency, and planned LocalStore caching in the user importing guide
- update the ingest pipeline doc to reflect today’s importer → UnitsService → Spectrum flow and capture LocalStore plans as next steps
- add a roadmap bullet for the GUI file dialog filter expansion and cross-link both docs to it

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f04313e5108329b8899d014cfb2a8a