### PR TITLE
Add line-shape modelling helper and overlay previews

### DIFF
--- a/app/data/reference/line_shape_placeholders.json
+++ b/app/data/reference/line_shape_placeholders.json
@@ -17,25 +17,53 @@
     {
       "id": "doppler_shift",
       "label": "Doppler shift",
-      "status": "todo",
+      "status": "ready",
       "description": "Implement relativistic Doppler shift corrections using rest wavelength reference and radial velocity inputs.",
       "parameters": ["rest_wavelength_nm", "radial_velocity_kms"],
+      "units": {
+        "rest_wavelength_nm": "nm",
+        "radial_velocity_kms": "km s⁻¹"
+      },
+      "example_parameters": {
+        "rest_wavelength_nm": 656.281,
+        "radial_velocity_kms": 45.0
+      },
       "notes": "Wire into plotting overlays once velocity metadata is stored alongside spectra."
     },
     {
       "id": "pressure_broadening",
       "label": "Pressure broadening",
-      "status": "todo",
+      "status": "ready",
       "description": "Integrate Lorentzian pressure broadening profiles using collisional half-widths from reference literature.",
-      "parameters": ["gamma_L", "perturber_density"],
+      "parameters": ["gamma_L", "perturber_density", "line_centre_nm"],
+      "units": {
+        "gamma_L": "nm·cm³",
+        "perturber_density": "cm⁻³",
+        "line_centre_nm": "nm"
+      },
+      "example_parameters": {
+        "gamma_L": 3.5e-16,
+        "perturber_density": 2.0e17,
+        "line_centre_nm": 486.133
+      },
       "notes": "Requires gas composition metadata and temperature-dependent coefficients."
     },
     {
       "id": "stark_broadening",
       "label": "Stark broadening",
-      "status": "todo",
+      "status": "ready",
       "description": "Placeholder for hydrogen Stark profiles relevant to Balmer line wings.",
-      "parameters": ["electron_density", "temperature_K"],
+      "parameters": ["electron_density", "temperature_K", "line_centre_nm"],
+      "units": {
+        "electron_density": "cm⁻³",
+        "temperature_K": "K",
+        "line_centre_nm": "nm"
+      },
+      "example_parameters": {
+        "electron_density": 5.0e14,
+        "temperature_K": 12000.0,
+        "line_centre_nm": 486.133
+      },
       "notes": "Targeting Vidal–Cooper–Smith tables as baseline values."
     },
     {

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -8,6 +8,7 @@ from .overlay_service import OverlayService
 from .math_service import MathService
 from .reference_library import ReferenceLibrary
 from .store import LocalStore
+from .line_shapes import LineShapeModel, LineShapeOutcome
 
 __all__ = [
     "Spectrum",
@@ -19,4 +20,6 @@ __all__ = [
     "MathService",
     "ReferenceLibrary",
     "LocalStore",
+    "LineShapeModel",
+    "LineShapeOutcome",
 ]

--- a/app/services/line_shapes.py
+++ b/app/services/line_shapes.py
@@ -1,0 +1,314 @@
+"""Utility helpers for applying bundled line-shape placeholder models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import numpy as np
+
+C_LIGHT_KMS = 299_792.458
+
+
+@dataclass(frozen=True)
+class LineShapeOutcome:
+    """Container for transformed arrays and provenance metadata."""
+
+    x: np.ndarray
+    y: np.ndarray
+    metadata: Dict[str, Any]
+
+
+class LineShapeModel:
+    """Apply Doppler, pressure, and Stark placeholders to spectral arrays."""
+
+    def __init__(
+        self,
+        placeholders: Sequence[Mapping[str, Any]],
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._definitions: Dict[str, Mapping[str, Any]] = {
+            str(entry.get("id")): entry for entry in placeholders if "id" in entry
+        }
+        meta = metadata or {}
+        references = meta.get("references") if isinstance(meta, Mapping) else None
+        if isinstance(references, list):
+            self._references = [ref for ref in references if isinstance(ref, Mapping)]
+        else:
+            self._references = []
+        self._notes = str(meta.get("notes", "")) if isinstance(meta, Mapping) else ""
+
+    # ------------------------------------------------------------------
+    def definition(self, model_id: str) -> Optional[Mapping[str, Any]]:
+        return self._definitions.get(model_id)
+
+    def example_parameters(self, model_id: str) -> Dict[str, Any]:
+        definition = self.definition(model_id)
+        if not isinstance(definition, Mapping):
+            return {}
+        params = definition.get("example_parameters")
+        if isinstance(params, Mapping):
+            return {str(k): v for k, v in params.items()}
+        return {}
+
+    # ------------------------------------------------------------------
+    def apply(
+        self,
+        model_id: str,
+        x: np.ndarray,
+        y: np.ndarray,
+        parameters: Mapping[str, Any] | None = None,
+    ) -> LineShapeOutcome:
+        model_id = str(model_id)
+        parameters = parameters or {}
+        params = {str(k): parameters[k] for k in parameters.keys()}
+        x_in = np.asarray(x, dtype=np.float64)
+        y_in = np.asarray(y, dtype=np.float64)
+
+        if model_id == "doppler_shift":
+            outcome = self._apply_doppler_shift(x_in, y_in, params)
+        elif model_id == "pressure_broadening":
+            outcome = self._apply_pressure_broadening(x_in, y_in, params)
+        elif model_id == "stark_broadening":
+            outcome = self._apply_stark_broadening(x_in, y_in, params)
+        else:
+            meta = {
+                "model": model_id,
+                "applied": False,
+                "reason": "unknown-model",
+                "parameters": params,
+            }
+            return LineShapeOutcome(np.array(x_in, copy=True), np.array(y_in, copy=True), meta)
+
+        outcome.metadata.setdefault("model", model_id)
+        outcome.metadata.setdefault("parameters", params)
+        if self._references:
+            outcome.metadata.setdefault(
+                "references",
+                [ref.get("citation") for ref in self._references if isinstance(ref, Mapping)],
+            )
+        if self._notes:
+            outcome.metadata.setdefault("notes", self._notes)
+        return outcome
+
+    def apply_sequence(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        specifications: Iterable[Mapping[str, Any]] | None,
+    ) -> Optional[LineShapeOutcome]:
+        specs = list(specifications or [])
+        if not specs:
+            return None
+
+        current_x = np.array(x, dtype=np.float64, copy=True)
+        current_y = np.array(y, dtype=np.float64, copy=True)
+        applied: List[Dict[str, Any]] = []
+
+        for spec in specs:
+            if not isinstance(spec, Mapping):
+                applied.append({"applied": False, "reason": "invalid-spec", "spec": spec})
+                continue
+            model_id = str(spec.get("model", ""))
+            params = spec.get("parameters")
+            params_map = params if isinstance(params, Mapping) else {}
+            outcome = self.apply(model_id, current_x, current_y, params_map)
+            current_x = outcome.x
+            current_y = outcome.y
+            applied.append({
+                "model": model_id,
+                "parameters": dict(params_map),
+                "result": outcome.metadata,
+            })
+
+        combined_meta: Dict[str, Any] = {
+            "applied": True,
+            "models": applied,
+        }
+        if self._references:
+            combined_meta["references"] = [
+                ref.get("citation") for ref in self._references if isinstance(ref, Mapping)
+            ]
+        return LineShapeOutcome(current_x, current_y, combined_meta)
+
+    # ------------------------------------------------------------------
+    def sample_profile(
+        self,
+        model_id: str,
+        parameters: Mapping[str, Any] | None = None,
+        grid: np.ndarray | None = None,
+    ) -> Optional[LineShapeOutcome]:
+        params = self.example_parameters(model_id)
+        if parameters:
+            for key, value in parameters.items():
+                params[str(key)] = value
+
+        centre = self._coerce_float(
+            params.get("rest_wavelength_nm")
+            or params.get("line_centre_nm")
+            or 656.281
+        )
+        if not np.isfinite(centre):
+            centre = 656.281
+
+        if grid is not None:
+            base_x = np.asarray(grid, dtype=np.float64)
+        else:
+            span = 3.0 if model_id == "doppler_shift" else 2.0
+            base_x = np.linspace(centre - span, centre + span, 801, dtype=np.float64)
+
+        sigma = 0.18 if model_id == "doppler_shift" else 0.12
+        base_profile = np.exp(-0.5 * ((base_x - centre) / sigma) ** 2)
+
+        outcome = self.apply(model_id, base_x, base_profile, params)
+        y = np.array(outcome.y, copy=True)
+        peak = float(np.nanmax(np.abs(y))) if y.size else 0.0
+        if peak > 0.0 and np.isfinite(peak):
+            y /= peak
+        outcome_meta = dict(outcome.metadata)
+        outcome_meta.setdefault("normalisation_peak", peak if peak else 1.0)
+        outcome_meta.setdefault("parameters", params)
+        return LineShapeOutcome(outcome.x, y, outcome_meta)
+
+    # ------------------------------------------------------------------
+    def _apply_doppler_shift(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        parameters: MutableMapping[str, Any],
+    ) -> LineShapeOutcome:
+        velocity = self._coerce_float(parameters.get("radial_velocity_kms"), default=0.0)
+        beta = float(np.clip(velocity / C_LIGHT_KMS, -0.95, 0.95))
+        factor = math.sqrt((1.0 + beta) / (1.0 - beta)) if abs(beta) < 1.0 else 1.0
+        shifted_x = x * factor
+        metadata: Dict[str, Any] = {
+            "applied": True,
+            "beta": beta,
+            "doppler_factor": factor,
+            "radial_velocity_kms": velocity,
+        }
+        rest_wavelength = self._coerce_float(parameters.get("rest_wavelength_nm"))
+        if rest_wavelength is not None and np.isfinite(rest_wavelength):
+            observed = rest_wavelength * factor
+            metadata["rest_wavelength_nm"] = rest_wavelength
+            metadata["observed_wavelength_nm"] = observed
+            metadata["delta_nm"] = observed - rest_wavelength
+        return LineShapeOutcome(shifted_x, np.array(y, copy=True), metadata)
+
+    def _apply_pressure_broadening(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        parameters: MutableMapping[str, Any],
+    ) -> LineShapeOutcome:
+        gamma_l = abs(self._coerce_float(parameters.get("gamma_L"), default=0.0) or 0.0)
+        density = abs(self._coerce_float(parameters.get("perturber_density"), default=0.0) or 0.0)
+        width = gamma_l * density
+        spacing = self._characteristic_spacing(x)
+        width = max(width, spacing * 0.25)
+
+        kernel = self._lorentz_kernel(width, spacing, size=401)
+        kernel_sum = float(kernel.sum())
+        if kernel_sum == 0.0 or not np.isfinite(kernel_sum):
+            kernel = np.zeros_like(kernel)
+            kernel[len(kernel) // 2] = 1.0
+            kernel_sum = 1.0
+        kernel /= kernel_sum
+
+        filled = np.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
+        broadened = np.convolve(filled, kernel, mode="same")
+        metadata = {
+            "applied": True,
+            "gamma_L": gamma_l,
+            "perturber_density": density,
+            "width_nm": width,
+            "kernel_size": int(kernel.size),
+            "kernel_sum": float(np.sum(kernel)),
+            "spacing_nm": spacing,
+        }
+        centre = self._coerce_float(parameters.get("line_centre_nm"))
+        if centre is not None and np.isfinite(centre):
+            metadata["line_centre_nm"] = centre
+        return LineShapeOutcome(np.array(x, copy=True), broadened, metadata)
+
+    def _apply_stark_broadening(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        parameters: MutableMapping[str, Any],
+    ) -> LineShapeOutcome:
+        electron_density = max(self._coerce_float(parameters.get("electron_density"), default=0.0) or 0.0, 0.0)
+        temperature = max(self._coerce_float(parameters.get("temperature_K"), default=10_000.0) or 10_000.0, 1.0)
+        spacing = self._characteristic_spacing(x)
+        base_width = 0.08
+        width = base_width * (electron_density / 1e14) ** 0.66 * (temperature / 10_000.0) ** 0.2
+        width = max(width, spacing * 0.35)
+
+        kernel = self._stark_kernel(width, spacing, size=401)
+        kernel_sum = float(kernel.sum())
+        if kernel_sum == 0.0 or not np.isfinite(kernel_sum):
+            kernel = np.zeros_like(kernel)
+            kernel[len(kernel) // 2] = 1.0
+            kernel_sum = 1.0
+        kernel /= kernel_sum
+
+        filled = np.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
+        broadened = np.convolve(filled, kernel, mode="same")
+        metadata = {
+            "applied": True,
+            "electron_density": electron_density,
+            "temperature_K": temperature,
+            "stark_width_nm": width,
+            "kernel_size": int(kernel.size),
+            "kernel_sum": float(np.sum(kernel)),
+            "spacing_nm": spacing,
+            "kernel_exponent": 2.5,
+        }
+        centre = self._coerce_float(parameters.get("line_centre_nm"))
+        if centre is not None and np.isfinite(centre):
+            metadata["line_centre_nm"] = centre
+        return LineShapeOutcome(np.array(x, copy=True), broadened, metadata)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _characteristic_spacing(x: np.ndarray) -> float:
+        finite = np.asarray(x[np.isfinite(x)], dtype=np.float64)
+        if finite.size < 2:
+            return 0.1
+        sorted_vals = np.sort(finite)
+        diffs = np.diff(sorted_vals)
+        diffs = diffs[np.isfinite(diffs) & (diffs > 0)]
+        if diffs.size == 0:
+            return max(float(np.nanmean(np.abs(sorted_vals))) * 0.01, 0.1)
+        return float(np.median(diffs))
+
+    @staticmethod
+    def _lorentz_kernel(width: float, spacing: float, *, size: int) -> np.ndarray:
+        half = size // 2
+        offsets = (np.arange(size) - half) * spacing
+        denom = offsets**2 + width**2
+        with np.errstate(divide="ignore"):
+            kernel = width / np.pi / denom
+        kernel[~np.isfinite(kernel)] = 0.0
+        return kernel
+
+    @staticmethod
+    def _stark_kernel(width: float, spacing: float, *, size: int) -> np.ndarray:
+        half = size // 2
+        offsets = np.abs((np.arange(size) - half) * spacing)
+        exponent = 2.5
+        with np.errstate(divide="ignore"):
+            kernel = 1.0 / (1.0 + (offsets / width) ** exponent)
+        kernel[~np.isfinite(kernel)] = 0.0
+        return kernel
+
+    @staticmethod
+    def _coerce_float(value: Any, *, default: Optional[float] = None) -> Optional[float]:
+        if value is None:
+            return default
+        try:
+            result = float(value)
+        except (TypeError, ValueError):
+            return default
+        return result

--- a/app/services/overlay_service.py
+++ b/app/services/overlay_service.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from .spectrum import Spectrum
 from .units_service import UnitsService
+from .line_shapes import LineShapeModel
 
 
 @dataclass
@@ -16,6 +17,7 @@ class OverlayService:
     """Store spectra and provide overlay-ready views."""
 
     units_service: UnitsService
+    line_shape_model: LineShapeModel | None = None
     _spectra: Dict[str, Spectrum] = field(default_factory=dict)
 
     def add(self, spectrum: Spectrum) -> None:
@@ -45,11 +47,26 @@ class OverlayService:
         for sid in spectrum_ids:
             spectrum = self._spectra[sid]
             canonical_y, norm_meta = self._apply_normalization(spectrum, normalization)
-            x_display, y_display = self.units_service.from_canonical(spectrum.x, canonical_y, x_unit, y_unit)
+            x_canonical = np.array(spectrum.x, dtype=np.float64, copy=True)
+            line_shape_specs = spectrum.metadata.get("line_shapes")
+            line_shape_metadata: Optional[Dict[str, Any]] = None
+            if self.line_shape_model and isinstance(line_shape_specs, list):
+                outcome = self.line_shape_model.apply_sequence(x_canonical, canonical_y, line_shape_specs)
+                if outcome is not None:
+                    x_canonical = outcome.x
+                    canonical_y = outcome.y
+                    line_shape_metadata = outcome.metadata
+            x_display, y_display = self.units_service.from_canonical(x_canonical, canonical_y, x_unit, y_unit)
             metadata: Dict[str, Any] = dict(spectrum.metadata)
             if norm_meta:
                 metadata = dict(metadata)  # shallow copy to avoid mutating cached metadata
                 metadata["normalization"] = norm_meta
+            if line_shape_metadata is not None:
+                metadata = dict(metadata)
+                metadata["line_shapes"] = {
+                    "specifications": list(line_shape_specs) if isinstance(line_shape_specs, list) else [],
+                    "results": line_shape_metadata,
+                }
             view: Dict[str, object] = {
                 "id": spectrum.id,
                 "name": spectrum.name,
@@ -58,7 +75,7 @@ class OverlayService:
                 "x_unit": x_unit,
                 "y_unit": y_unit,
                 "metadata": metadata,
-                "x_canonical": np.array(spectrum.x, copy=True),
+                "x_canonical": np.array(x_canonical, copy=True),
                 "y_canonical": canonical_y,
             }
             views.append(view)

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,14 @@
 # Patch Notes
 
+## 2025-10-16 (Line-shape previews & overlay integration) (11:45 am UTC)
+
+- Promoted Doppler, pressure, and Stark placeholders to `ready` with units and example parameters so the Inspector can seed
+  sample profiles from the reference catalogue.
+- Added a `LineShapeModel` service that parses the placeholder definitions, applies relativistic Doppler shifts, Lorentzian
+  pressure kernels, and Stark wing scaling, exposing the results to the overlay pipeline with provenance metadata.
+- Updated the Reference Inspector to preview the simulated profiles, wire selection changes into the overlay toggle, and added
+  regression coverage plus documentation updates for the new controls.
+
 ## 2025-10-16 (IR overlay anchoring documentation) (9:30 am UTC)
 
 - Documented the anchored IR functional-group overlays and label stacking safeguards in

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -141,7 +141,7 @@
 
 # Workplan — Batch 10 (Backlog)
 
-- [ ] Wire Doppler/pressure/Stark broadening models into the overlay service using the placeholder parameter scaffolding.
+- [x] Wire Doppler/pressure/Stark broadening models into the overlay service using the placeholder parameter scaffolding (LineShapeModel service, Inspector preview, regression tests).
 - [ ] Replace digitised JWST tables with calibrated FITS ingestion and provenance links once the pipeline module is ready.
 - [ ] Expand the spectral line catalogue beyond hydrogen (e.g. He I, O III, Fe II) with citations and regression coverage.
 - [ ] Integrate IR functional group heuristics into importer header parsing for automated axis validation.

--- a/docs/user/reference_data.md
+++ b/docs/user/reference_data.md
@@ -33,10 +33,14 @@ authoritative NIST assets from digitised JWST placeholders that still need regen
 ## Line-shape placeholders
 
 - References: B.W. Mangum & S. Shirley (2015) PASP 127, 266–298; G. Herzberg (1950) *Spectra of Diatomic Molecules*.
-- Purpose: captures TODO scaffolding for Doppler shifts, pressure/Stark broadening, and instrumental resolution so the
+- Purpose: captures Doppler shifts, pressure and Stark broadening, instrumental resolution, and other scaffolding so the
   feature backlog is visible to users and agents.
-- Usage: select **Line-shape Placeholders** to review planned parameters before integrating physics models. Each entry
-  is marked with a status flag (currently `todo`).
+- Models marked `ready` (Doppler shift, pressure broadening, Stark broadening) now include physical units and example
+  parameters pulled from those references. Highlighting a row renders a normalised sample profile and records Doppler
+  factors, Lorentzian kernel widths, or Stark wing scaling derived from the seeded inputs.
+- Usage: select **Line-shape Placeholders** and click a row to refresh the preview plot. The **Overlay on plot** toggle
+  projects the simulated profile into the main workspace, letting you compare the seeded broadening or velocity shift
+  against active spectra before wiring real metadata into the pipeline.
 
 ## JWST quick-look spectra
 

--- a/tests/test_line_shapes.py
+++ b/tests/test_line_shapes.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.line_shapes import LineShapeModel
+from app.services.reference_library import ReferenceLibrary
+
+
+@pytest.fixture(scope="module")
+def line_shape_model() -> LineShapeModel:
+    library = ReferenceLibrary()
+    return LineShapeModel(library.line_shape_placeholders(), library.line_shape_metadata())
+
+
+def test_doppler_shift_relativistic_factor(line_shape_model: LineShapeModel) -> None:
+    params = line_shape_model.example_parameters("doppler_shift")
+    rest = float(params.get("rest_wavelength_nm", 656.281))
+    beta = float(params.get("radial_velocity_kms", 0.0)) / 299_792.458
+    x = np.linspace(rest - 1.0, rest + 1.0, 51)
+    y = np.ones_like(x)
+
+    outcome = line_shape_model.apply("doppler_shift", x, y, params)
+    factor = np.sqrt((1.0 + beta) / (1.0 - beta))
+
+    assert np.allclose(outcome.x, x * factor)
+    assert outcome.metadata["doppler_factor"] == pytest.approx(factor)
+    assert outcome.metadata["beta"] == pytest.approx(beta)
+    assert outcome.metadata["observed_wavelength_nm"] == pytest.approx(rest * factor)
+
+
+def test_pressure_broadening_kernel_normalisation(line_shape_model: LineShapeModel) -> None:
+    params = line_shape_model.example_parameters("pressure_broadening")
+    centre = float(params.get("line_centre_nm", 486.133))
+    x = np.linspace(centre - 1.0, centre + 1.0, 801)
+    y = np.exp(-0.5 * ((x - centre) / 0.04) ** 2)
+
+    outcome = line_shape_model.apply("pressure_broadening", x, y, params)
+
+    assert outcome.metadata["kernel_sum"] == pytest.approx(1.0, rel=1e-6)
+    assert outcome.metadata["width_nm"] > 0
+    assert outcome.y.max() < y.max()
+
+
+def test_stark_broadening_wings_gain_weight(line_shape_model: LineShapeModel) -> None:
+    params = line_shape_model.example_parameters("stark_broadening")
+    centre = float(params.get("line_centre_nm", 486.133))
+    x = np.linspace(centre - 2.0, centre + 2.0, 1201)
+    y = np.exp(-0.5 * ((x - centre) / 0.05) ** 2)
+
+    outcome = line_shape_model.apply("stark_broadening", x, y, params)
+    wings = np.abs(x - centre) > 0.4
+
+    assert outcome.metadata["stark_width_nm"] > 0
+    assert outcome.metadata["kernel_sum"] == pytest.approx(1.0, rel=1e-6)
+    assert outcome.y[wings].sum() > y[wings].sum()


### PR DESCRIPTION
## Summary
- mark Doppler, pressure, and Stark placeholder models as ready with units and seeded parameters for the inspector
- add a LineShapeModel service that applies Doppler shifts plus pressure and Stark broadening for overlays and previews
- render interactive line-shape previews in the Reference tab, enable overlay projection, and document and test the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f04eff5bfc8329b2bb62020d7d04d2