### PR TITLE
Refactor reference overlay state lifecycle

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -246,3 +246,15 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
 **References**: `app/main.py`, `tests/test_smoke_workflow.py`, `docs/reviews/workplan.md`.
 
 ---
+
+## 2025-10-16 13:50 – Reference UI Overlay State
+
+**Author**: agent
+
+**Context**: Reference inspector overlay cleanup and regression coverage.
+
+**Summary**: Collapsed duplicate overlay attribute initialisation in the preview shell and introduced `_reset_reference_overlay_state()` so every clear path shares a single bookkeeping helper, keeping the payload dictionary and annotation list stable across toggles.【F:app/main.py†L60-L75】【F:app/main.py†L174-L192】【F:app/main.py†L229-L244】 Added a GUI regression test that flips the overlay checkbox to assert the payload object survives clears, preventing future refactors from dropping labels mid-session.【F:tests/test_reference_ui.py†L8-L118】 Updated the plotting guide and patch notes to call out the single-source overlay state for operators tracking behaviour changes.【F:docs/user/plot_tools.md†L58-L74】【F:docs/history/PATCH_NOTES.md†L1-L12】
+
+**References**: `app/main.py`, `tests/test_reference_ui.py`, `docs/user/plot_tools.md`, `docs/history/PATCH_NOTES.md`.
+
+---

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,14 @@
 # Patch Notes
 
+## 2025-10-16 (Reference overlay state consolidation) (1:50 pm UTC)
+
+- Deduplicated the Reference inspector's overlay attributes so the payload, key, and annotations initialise once at startup and
+  reset through a shared helper when overlays are cleared.
+- Added `_reset_reference_overlay_state()` to centralise cleanup paths, ensuring toggles reuse the existing payload dictionary
+  and annotation list rather than replacing them mid-session.
+- Extended the GUI regression suite to cover overlay toggling semantics and updated the plotting guide to mention the
+  single-source overlay bookkeeping; logged the activity in the consolidated knowledge log for traceability.
+
 ## 2025-10-16 (Line-shape previews & overlay integration) (11:45 am UTC)
 
 - Promoted Doppler, pressure, and Stark placeholders to `ready` with units and example parameters so the Inspector can seed

--- a/docs/user/plot_tools.md
+++ b/docs/user/plot_tools.md
@@ -45,6 +45,10 @@ Reference overlays adopt the scaling of the active plot so annotations land wher
 - Use **View → Reset Plot** to reapply auto-range—the overlay matches the recomputed intensity span.
 - Confirm no hidden traces define the axis limits; even invisible datasets can contribute to the active span if their visibility checkbox remains enabled.
 
+The Reference inspector now keeps a single source of truth for overlay bookkeeping, so toggling the checkbox reuses the existing
+payload and annotations rather than rebuilding empty containers. That means manual labels and band settings persist between
+clears until you load a different dataset or regenerate the payload from the inspector table.
+
 Automated coverage in `tests/test_reference_ui.py::test_ir_overlay_labels_stack_inside_band` protects the label-spacing logic, so overlap usually signals that the active axis is extremely compressed. Widening the y-range or temporarily disabling normalisation restores the expected layout.
 
 ## Level-of-detail safeguards

--- a/tests/test_reference_ui.py
+++ b/tests/test_reference_ui.py
@@ -197,3 +197,52 @@ def test_line_shape_preview_populates_overlay_payload() -> None:
         window.close()
         window.deleteLater()
         app.processEvents()
+
+
+def test_reference_overlay_toggle_preserves_payload_object() -> None:
+    if SpectraMainWindow is None or QtWidgets is None:
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    pytest.importorskip("pyqtgraph")
+
+    app = _ensure_app()
+    window = SpectraMainWindow()
+    try:
+        band_bottom, band_top = window._overlay_band_bounds()
+        payload = {
+            "key": "reference::regression::toggle",
+            "alias": "Reference – Toggle Regression",
+            "x_nm": np.array([410.0, 410.0, 520.0, 520.0, np.nan], dtype=float),
+            "y": np.array([band_bottom, band_top, band_top, band_bottom, np.nan], dtype=float),
+            "color": "#4F6D7A",
+            "width": 1.2,
+            "fill_color": (79, 109, 122, 90),
+            "fill_level": float(band_bottom),
+            "band_bounds": (float(band_bottom), float(band_top)),
+            "labels": [
+                {"text": "Feature", "centre_nm": 465.0},
+            ],
+        }
+
+        window._update_reference_overlay_state(payload)
+        assert window._reference_overlay_payload is payload
+
+        annotations_list = window._reference_overlay_annotations
+        window.reference_overlay_checkbox.setChecked(True)
+        app.processEvents()
+
+        assert window._reference_overlay_payload is payload
+        assert window._reference_overlay_annotations is annotations_list
+        assert window._reference_overlay_annotations
+
+        window.reference_overlay_checkbox.setChecked(False)
+        app.processEvents()
+
+        assert window._reference_overlay_payload is payload
+        assert window._reference_overlay_annotations is annotations_list
+        assert not window._reference_overlay_annotations
+    finally:
+        window._clear_reference_overlay()
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- collapse duplicate reference overlay attribute initialisation and centralise cleanup in a `_reset_reference_overlay_state()` helper
- update overlay clearing paths to reuse the payload/annotation containers and document the single-source overlay state in user history and guides
- add regression coverage to ensure toggling the overlay checkbox preserves the payload dictionary

## Testing
- pytest tests/test_reference_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68f0594becd88329858cb4c2ae3fdec5