### PR TITLE
Add automatic LocalStore caching to ingest workflow

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -258,3 +258,22 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
 **References**: `app/main.py`, `tests/test_reference_ui.py`, `docs/user/plot_tools.md`, `docs/history/PATCH_NOTES.md`.
 
 ---
+
+## 2025-10-16 14:30 – Local Cache Integration
+
+**Author**: agent
+
+**Context**: Automatic LocalStore writes and persistence controls for ingest.
+
+**Summary**: Updated the ingest pipeline to accept a shared `LocalStore`,
+recording canonical-unit provenance for every import and annotating spectra with
+cache metadata so repeated loads reuse prior manifests.【F:app/services/data_ingest_service.py†L11-L72】 Wired the preview shell
+to construct the store, expose an environment override and menu toggle for
+persistence, and feed the instance into manual and sample ingest paths.【F:app/main.py†L1-L131】 Regression coverage now mocks the
+store to confirm `record` invocations and metadata reuse, and the importing guide
+and patch notes document the automatic caching behaviour and opt-out flow.【F:tests/test_cache_index.py†L1-L123】【F:docs/user/importing.md†L7-L38】【F:docs/history/PATCH_NOTES.md†L1-L10】
+
+**References**: `app/services/data_ingest_service.py`, `app/main.py`,
+`tests/test_cache_index.py`, `docs/user/importing.md`, `docs/history/PATCH_NOTES.md`.
+
+---

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,16 @@
 # Patch Notes
 
+## 2025-10-16 (Automatic ingest caching) (2:30 pm UTC)
+
+- Wired `DataIngestService` to accept a `LocalStore`, recording canonical units
+  and provenance metadata after every import so the cache index updates without
+  manual intervention.
+- Instantiated a shared `LocalStore` in the preview shell with a toggleable
+  persistence preference (plus the `SPECTRA_DISABLE_PERSISTENCE` environment
+  override) so manual imports and sample loads land in the cache consistently.
+- Documented the new behaviour, regression coverage, and knowledge-log entry to
+  highlight the automatic caching flow and opt-out controls.
+
 ## 2025-10-16 (Reference overlay state consolidation) (1:50 pm UTC)
 
 - Deduplicated the Reference inspector's overlay attributes so the payload, key, and annotations initialise once at startup and

--- a/docs/user/importing.md
+++ b/docs/user/importing.md
@@ -6,7 +6,8 @@ The **File → Open** picker currently filters to comma-separated (`*.csv`,
 into the filename field until the [GUI filter expansion roadmap
 item](../../reports/roadmap.md#gui-file-dialog-filter-expansion) lands. Imported
 arrays are normalised into the app's canonical wavelength baseline of
-nanometres while preserving the raw data on disk for provenance.
+nanometres while the desktop build now copies the raw upload into the local
+cache for provenance-aware reuse.
 
 ## Supported formats
 
@@ -26,13 +27,18 @@ nanometres while preserving the raw data on disk for provenance.
 
 1. Choose **File → Open** and select one or more spectra (hold `Ctrl` or `Shift` to pick multiple files in a single pass).
 2. Review the detected units shown in the preview banner.
-3. Confirm the ingest. The spectrum is normalised in-memory; LocalStore-based
-   caching is planned but not yet wired into the desktop build.
+3. Confirm the ingest. The spectrum is normalised in-memory and the
+   provenance-aware cache records the canonical units alongside a copy of the
+   upload so repeat loads avoid re-parsing.
 
-> **Planned enhancement**: The `LocalStore` cache integration will copy the raw
-> upload alongside the canonical arrays so repeat loads avoid re-parsing. Track
-> progress via the [GUI filter expansion roadmap
-> entry](../../reports/roadmap.md#gui-file-dialog-filter-expansion).
+### Cache persistence controls
+
+The ingest pipeline now writes to the on-disk cache automatically, which keeps
+track of canonical units, importer provenance, and SHA256 hashes for deduping.
+You can opt out temporarily by setting the environment variable
+`SPECTRA_DISABLE_PERSISTENCE=1` before launching the app. When the environment
+flag is not set, toggle **File → Enable Persistent Cache** to persist the
+preference between sessions.
 
 Imported spectra always appear in canonical units inside the application. Use
  the unit toggle on the toolbar to view alternative axes without mutating the


### PR DESCRIPTION
## Summary
- update `DataIngestService` to record imports in `LocalStore`, annotating spectra with cache metadata
- construct a shared `LocalStore` in the desktop shell with an environment override and menu toggle for persistence
- document the automatic caching behaviour and extend regression coverage around cache usage

## Testing
- pytest tests/test_cache_index.py

------
https://chatgpt.com/codex/tasks/task_e_68f05b77c9f88329a83ad710d6e7d79a