### PR TITLE
Make plot LOD limit configurable

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -309,3 +309,15 @@ and patch notes document the automatic caching behaviour and opt-out flow.【F:t
 `tests/test_cache_index.py`, `docs/user/importing.md`, `docs/history/PATCH_NOTES.md`.
 
 ---
+
+## 2025-10-16 23:55 – Plot LOD Preference Control
+
+**Author**: agent
+
+**Context**: User-configurable downsampling budget for the plot pane.
+
+**Summary**: Added a persisted "LOD point budget" spinner to the Inspector Style tab so analysts can adjust the downsampling envelope between 1k and 1M samples without leaving the session; the control writes through `QSettings` and immediately refreshes visible traces.【F:app/main.py†L76-L116】【F:app/main.py†L214-L275】【F:app/main.py†L410-L520】 Updated `PlotPane` to accept a constructor-provided limit, clamp invalid values, and expose a setter that re-renders existing traces on change.【F:app/ui/plot_pane.py†L35-L304】 Extended the plot performance stub to assert overrides and clamping, keeping the peak-envelope decimator aligned with the configured budget.【F:tests/test_plot_perf_stub.py†L14-L63】 Documented the new preference in the plotting guide and patch notes for operator awareness.【F:docs/user/plot_tools.md†L56-L65】【F:docs/history/PATCH_NOTES.md†L3-L8】
+
+**References**: `app/main.py`, `app/ui/plot_pane.py`, `tests/test_plot_perf_stub.py`, `docs/user/plot_tools.md`, `docs/history/PATCH_NOTES.md`.
+
+---

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,11 @@
 # Patch Notes
 
+## 2025-10-16 (Adjustable plot LOD budget) (11:55 pm UTC)
+
+- Added a configurable "LOD point budget" control to the Inspector Style tab so users can raise or lower the plot downsampling threshold from 1k to 1M samples while Spectra persists the preference via `QSettings`.
+- Taught `PlotPane` to accept a constructor-provided budget with validation plus a runtime setter that clamps unreasonable values and re-renders existing traces accordingly.
+- Extended the plot performance stub tests to exercise the override path and ensure the peak-envelope downsampling honours the user-selected limit, alongside documentation updates for the new control.
+
 ## 2025-10-16 (Remote catalogue ingestion) (11:10 pm UTC)
 
 - Added a `RemoteDataService` with dependency guards for `requests`/`astroquery`,

--- a/docs/user/plot_tools.md
+++ b/docs/user/plot_tools.md
@@ -55,9 +55,9 @@ Automated coverage in `tests/test_reference_ui.py::test_ir_overlay_labels_stack_
 
 ## Level-of-detail safeguards
 
-High-resolution spectra can contain millions of samples. Rendering every point would make panning and zooming sluggish, so the plot pane automatically enforces a peak-envelope LOD cap:
+High-resolution spectra can contain millions of samples. Rendering every point would make panning and zooming sluggish, so the plot pane automatically enforces a peak-envelope LOD cap. The default budget renders up to **120,000** points per trace exactly as provided, but you can tailor the threshold under **Inspector → Style → LOD point budget**. The spinner ranges from 1,000 to 1,000,000 samples so dense imports stay interactive on modest GPUs.
 
-- Up to **120,000** points per trace render exactly as provided.
+- Up to the configured cap render exactly as provided.
 - Above that threshold, the x-axis is segmented and each block collapses into alternating min/max samples that preserve peaks.
 - The tail of a trace that does not align perfectly with the segmentation is appended without modification so you never lose edge information.
 


### PR DESCRIPTION
## Summary
- teach `PlotPane` to accept a configurable LOD point budget with validation and runtime updates
- expose the downsampling preference in the Inspector Style tab, persisting it via `QSettings`
- extend plotting documentation, patch notes, and tests to cover the adjustable limit

## Testing
- pytest tests/test_plot_perf_stub.py


------
https://chatgpt.com/codex/tasks/task_e_68f0670553cc8329b4632b544f3ddc44