### PR TITLE
Handle missing remote data dependencies gracefully

### DIFF
--- a/docs/user/remote_data.md
+++ b/docs/user/remote_data.md
@@ -5,6 +5,14 @@ desktop preview. Searches are routed through provider-specific adapters and the
 downloads are cached in your local Spectra data directory so you can re-open
 them even when offline.
 
+> **Optional dependencies**
+>
+> Remote catalogues rely on third-party clients. The NIST adapter requires the
+> [`requests`](https://docs.python-requests.org/) package, while MAST lookups
+> also need [`astroquery`](https://astroquery.readthedocs.io/). If either
+> dependency is missing the dialog will list the provider as unavailable and the
+> search controls remain disabled until the package is installed.
+
 ## Opening the dialog
 
 1. Choose **File → Fetch Remote Data…** (or press `Ctrl+Shift+R`).


### PR DESCRIPTION
## Summary
- hide remote catalogue providers when optional dependencies are missing and expose reasons via `unavailable_providers`
- disable the Remote Data dialog controls when providers are unavailable and surface dependency hints in the UI
- document the optional requirements for remote catalogues and add regression coverage for the new dependency gating logic

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f04d8003bc8329a07ea8c9e4e0af99