### PR TITLE
Support provider-specific remote search criteria

### DIFF
--- a/app/services/remote_data_service.py
+++ b/app/services/remote_data_service.py
@@ -155,7 +155,7 @@ class RemoteDataService:
         session = self._ensure_session()
         params: Dict[str, Any] = {
             "format": "json",
-            "spectra": query.get("element") or query.get("text") or "",
+            "spectra": query.get("element") or query.get("spectra") or query.get("text") or "",
         }
         if query.get("wavelength_min") is not None:
             params["wavemin"] = query["wavelength_min"]
@@ -206,6 +206,9 @@ class RemoteDataService:
     def _search_mast(self, query: Mapping[str, Any]) -> List[RemoteRecord]:
         observations = self._ensure_mast()
         criteria = dict(query)
+        text = criteria.pop("text", None)
+        if text and not criteria.get("target_name"):
+            criteria["target_name"] = text
         table = observations.Observations.query_criteria(**criteria)
         rows = self._table_to_records(table)
         records: List[RemoteRecord] = []

--- a/app/ui/remote_data_dialog.py
+++ b/app/ui/remote_data_dialog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 from app.qt_compat import get_qt
 from app.services import DataIngestService, RemoteDataService, RemoteRecord
@@ -14,6 +14,20 @@ QtCore, QtGui, QtWidgets, _ = get_qt()
 
 class RemoteDataDialog(QtWidgets.QDialog):
     """Interactive browser for remote catalogue search and download."""
+
+    _MAST_SUPPORTED_CRITERIA = {
+        "target_name",
+        "obs_collection",
+        "dataproduct_type",
+        "instrument_name",
+        "proposal_id",
+        "proposal_pi",
+        "filters",
+        "s_ra",
+        "s_dec",
+        "radius",
+    }
+    _MAST_NUMERIC_CRITERIA = {"s_ra", "s_dec", "radius"}
 
     def __init__(
         self,
@@ -96,7 +110,8 @@ class RemoteDataDialog(QtWidgets.QDialog):
     # ------------------------------------------------------------------
     def _on_search(self) -> None:
         provider = self.provider_combo.currentText()
-        query = {"text": self.search_edit.text().strip()}
+        text = self.search_edit.text().strip()
+        query = self._build_query_for_provider(provider, text)
         try:
             records = self.remote_service.search(provider, query)
         except Exception as exc:  # pragma: no cover - UI feedback
@@ -114,6 +129,55 @@ class RemoteDataDialog(QtWidgets.QDialog):
             self.results.selectRow(0)
         else:
             self.preview.clear()
+
+    # ------------------------------------------------------------------
+    def _build_query_for_provider(self, provider: str, text: str) -> Dict[str, object]:
+        if provider == RemoteDataService.PROVIDER_NIST:
+            return {"spectra": text} if text else {}
+        if provider == RemoteDataService.PROVIDER_MAST:
+            return self._build_mast_criteria(text)
+        return {"text": text} if text else {}
+
+    def _build_mast_criteria(self, text: str) -> Dict[str, object]:
+        text = text.strip()
+        if not text:
+            return {}
+
+        if "=" in text or ":" in text:
+            criteria: Dict[str, object] = {}
+            tokens = [token.strip() for token in text.split(",") if token.strip()]
+            for token in tokens:
+                key, value = self._split_token(token)
+                if key is None or value is None:
+                    criteria.clear()
+                    break
+                if key not in self._MAST_SUPPORTED_CRITERIA:
+                    criteria.clear()
+                    break
+                if key in self._MAST_NUMERIC_CRITERIA:
+                    try:
+                        criteria[key] = float(value)
+                    except ValueError:
+                        criteria.clear()
+                        break
+                else:
+                    criteria[key] = value
+            if criteria:
+                return criteria
+
+        return {"target_name": text}
+
+    @staticmethod
+    def _split_token(token: str) -> tuple[str | None, str | None]:
+        if "=" in token:
+            key, _, value = token.partition("=")
+        else:
+            key, _, value = token.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            return None, None
+        return key, value
 
     def _update_preview(self) -> None:
         indexes = self.results.selectionModel().selectedRows()

--- a/docs/user/remote_data.md
+++ b/docs/user/remote_data.md
@@ -21,7 +21,12 @@ them even when offline.
    - **NIST ASD** (line lists via the Atomic Spectra Database)
    - **MAST** (MAST data products via `astroquery.mast`)
 3. Enter a keyword, element symbol, or target name in the search field and click
-   **Search**.
+   **Search**. The dialog adapts the criteria to the selected provider:
+   - **NIST ASD** interprets the text as the `spectra` field that powers the
+     Atomic Spectra Database line search.
+   - **MAST** treats free-form text as a `target_name`, or you can provide
+     comma-separated `key=value` pairs for supported `astroquery.mast`
+     parameters (for example `instrument_name=NIRSpec, dataproduct_type=spectrum`).
 
 The results table displays identifiers, titles, and the source URI for each
 match. Selecting a row shows the raw metadata payload in the preview panel so

--- a/tests/test_remote_data_dialog.py
+++ b/tests/test_remote_data_dialog.py
@@ -1,0 +1,76 @@
+"""Regression coverage for the remote data discovery dialog."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+try:  # pragma: no cover - optional dependency guard
+    from app.services import RemoteDataService
+    from app.ui.remote_data_dialog import RemoteDataDialog
+    from app.qt_compat import get_qt
+except ImportError as exc:  # pragma: no cover - exercised via skip path
+    RemoteDataDialog = None  # type: ignore[assignment]
+    RemoteDataService = None  # type: ignore[assignment]
+    _qt_import_error = exc
+    QtWidgets = None  # type: ignore[assignment]
+else:  # pragma: no cover - covered when Qt stack is present
+    _qt_import_error = None
+    QtCore, QtGui, QtWidgets, _ = get_qt()
+
+
+def _ensure_app() -> "QtWidgets.QApplication":
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+@pytest.mark.skipif(RemoteDataDialog is None or QtWidgets is None, reason="Qt stack unavailable")
+def test_remote_dialog_translates_mast_search() -> None:
+    app = _ensure_app()
+
+    class DummyRemoteService:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        def providers(self) -> list[str]:
+            return [RemoteDataService.PROVIDER_NIST, RemoteDataService.PROVIDER_MAST]
+
+        def unavailable_providers(self) -> dict[str, str]:
+            return {}
+
+        def search(self, provider: str, query: dict[str, Any]):
+            self.calls.append((provider, query))
+            return []
+
+        def download(self, record):  # pragma: no cover - dialog test does not download
+            raise AssertionError("download should not be invoked during search")
+
+    class DummyIngestService:
+        def ingest(self, path):  # pragma: no cover - dialog test does not ingest
+            raise AssertionError("ingest should not be invoked during search")
+
+    remote = DummyRemoteService()
+    dialog = RemoteDataDialog(None, remote_service=remote, ingest_service=DummyIngestService())
+
+    try:
+        index = dialog.provider_combo.findText(RemoteDataService.PROVIDER_MAST)
+        assert index != -1
+        dialog.provider_combo.setCurrentIndex(index)
+        dialog.search_edit.setText("WASP-96 b")
+
+        dialog._on_search()
+        app.processEvents()
+
+        assert remote.calls, "search should invoke the remote service"
+        provider, query = remote.calls[-1]
+        assert provider == RemoteDataService.PROVIDER_MAST
+        assert query == {"target_name": "WASP-96 b"}
+    finally:
+        dialog.close()
+        dialog.deleteLater()
+        app.processEvents()

--- a/tests/test_remote_data_service.py
+++ b/tests/test_remote_data_service.py
@@ -141,6 +141,27 @@ def test_search_mast_table_conversion(store: LocalStore, monkeypatch: pytest.Mon
     assert records[0].units == {"x": "um", "y": "flux"}
 
 
+def test_search_mast_rewrites_text_to_target_name(store: LocalStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class DummyObservations:
+        @staticmethod
+        def query_criteria(**criteria: Any) -> list[dict[str, Any]]:
+            captured.update(criteria)
+            return []
+
+    class DummyMast:
+        Observations = DummyObservations
+
+    service = RemoteDataService(store, session=None)
+    monkeypatch.setattr(service, "_ensure_mast", lambda: DummyMast)
+
+    records = service.search(RemoteDataService.PROVIDER_MAST, {"text": "WASP-96 b"})
+
+    assert records == []
+    assert captured["target_name"] == "WASP-96 b"
+
+
 def test_providers_hide_missing_dependencies(monkeypatch: pytest.MonkeyPatch, store: LocalStore) -> None:
     monkeypatch.setattr(remote_module, "requests", None)
     monkeypatch.setattr(remote_module, "astroquery_mast", None)


### PR DESCRIPTION
## Summary
- map the Remote Data dialog search box to provider-specific query payloads and validate supported MAST criteria
- allow the remote data service to accept `spectra` hints for NIST and rewrite free-text MAST queries to `target_name`
- document the provider-specific hints and add regression tests for both the UI and service layers

## Testing
- pytest tests/test_remote_data_service.py::test_search_mast_rewrites_text_to_target_name
- pytest tests/test_remote_data_dialog.py::test_remote_dialog_translates_mast_search

------
https://chatgpt.com/codex/tasks/task_e_68f113d67d6c8329afd37a03ed523dab