### PR TITLE
Translate MAST search text before invoking astroquery

### DIFF
--- a/app/services/remote_data_service.py
+++ b/app/services/remote_data_service.py
@@ -207,6 +207,8 @@ class RemoteDataService:
         observations = self._ensure_mast()
         criteria = dict(query)
         text = criteria.pop("text", None)
+        if isinstance(text, str):
+            text = text.strip()
         if text and not criteria.get("target_name"):
             criteria["target_name"] = text
         table = observations.Observations.query_criteria(**criteria)

--- a/app/ui/remote_data_dialog.py
+++ b/app/ui/remote_data_dialog.py
@@ -110,7 +110,7 @@ class RemoteDataDialog(QtWidgets.QDialog):
     # ------------------------------------------------------------------
     def _on_search(self) -> None:
         provider = self.provider_combo.currentText()
-        text = self.search_edit.text().strip()
+        text = self.search_edit.text()
         query = self._build_query_for_provider(provider, text)
         try:
             records = self.remote_service.search(provider, query)
@@ -132,6 +132,7 @@ class RemoteDataDialog(QtWidgets.QDialog):
 
     # ------------------------------------------------------------------
     def _build_query_for_provider(self, provider: str, text: str) -> Dict[str, object]:
+        text = text.strip()
         if provider == RemoteDataService.PROVIDER_NIST:
             return {"spectra": text} if text else {}
         if provider == RemoteDataService.PROVIDER_MAST:

--- a/tests/test_remote_data_dialog.py
+++ b/tests/test_remote_data_dialog.py
@@ -61,7 +61,7 @@ def test_remote_dialog_translates_mast_search() -> None:
         index = dialog.provider_combo.findText(RemoteDataService.PROVIDER_MAST)
         assert index != -1
         dialog.provider_combo.setCurrentIndex(index)
-        dialog.search_edit.setText("WASP-96 b")
+        dialog.search_edit.setText("  WASP-96 b  ")
 
         dialog._on_search()
         app.processEvents()

--- a/tests/test_remote_data_service.py
+++ b/tests/test_remote_data_service.py
@@ -156,10 +156,15 @@ def test_search_mast_rewrites_text_to_target_name(store: LocalStore, monkeypatch
     service = RemoteDataService(store, session=None)
     monkeypatch.setattr(service, "_ensure_mast", lambda: DummyMast)
 
-    records = service.search(RemoteDataService.PROVIDER_MAST, {"text": "WASP-96 b"})
+    records = service.search(
+        RemoteDataService.PROVIDER_MAST,
+        {"text": "  WASP-96 b  ", "obs_collection": "JWST"},
+    )
 
     assert records == []
     assert captured["target_name"] == "WASP-96 b"
+    assert captured["obs_collection"] == "JWST"
+    assert "text" not in captured
 
 
 def test_providers_hide_missing_dependencies(monkeypatch: pytest.MonkeyPatch, store: LocalStore) -> None:


### PR DESCRIPTION
## Summary
- ensure the remote data dialog strips and translates free-text searches into provider-specific kwargs before dispatching the query
- trim free-text criteria inside the MAST search implementation so blank padding is dropped before forwarding to astroquery
- extend remote data service and dialog tests to cover whitespace trimming and preserving additional criteria for MAST searches

## Testing
- pytest tests/test_remote_data_service.py -q
- pytest tests/test_remote_data_dialog.py -q


------
https://chatgpt.com/codex/tasks/task_e_68f1168f14f083298abe294ad92df8ab