### PR TITLE
Handle MAST downloads via astroquery

### DIFF
--- a/app/services/remote_data_service.py
+++ b/app/services/remote_data_service.py
@@ -137,6 +137,8 @@ class RemoteDataService:
                 tmp_path = Path(handle.name)
             cleanup_tmp = True
 
+        tmp_path = Path(tmp_path)
+
         x_unit, y_unit = record.resolved_units()
         remote_metadata = {
             "provider": record.provider,

--- a/tests/test_remote_data_service.py
+++ b/tests/test_remote_data_service.py
@@ -134,7 +134,7 @@ def test_download_mast_uses_astroquery_and_records_provenance(
     class DummyMast:
         Observations = DummyObservations
 
-    monkeypatch.setattr(service, "_ensure_mast", lambda: DummyMast)
+    monkeypatch.setattr(remote_module, "astroquery_mast", DummyMast, raising=False)
 
     record = RemoteRecord(
         provider=RemoteDataService.PROVIDER_MAST,
@@ -153,6 +153,7 @@ def test_download_mast_uses_astroquery_and_records_provenance(
     stored_path = Path(result.cache_entry["stored_path"])
     assert stored_path.exists()
     assert stored_path.read_bytes() == payload
+    assert result.cache_entry["original_path"] == str(downloaded)
 
     remote_meta = result.cache_entry.get("source", {}).get("remote", {})
     assert remote_meta.get("provider") == RemoteDataService.PROVIDER_MAST
@@ -166,6 +167,7 @@ def test_download_mast_uses_astroquery_and_records_provenance(
     assert cached.cached is True
     assert len(mast_calls) == before
     assert Path(cached.cache_entry["stored_path"]) == stored_path
+    assert cached.cache_entry["original_path"] == str(downloaded)
 
 
 def test_search_mast_table_conversion(store: LocalStore, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- ensure MAST downloads normalise the astroquery returned path before caching
- update the MAST download test to exercise the astroquery downloader and verify caching behaviour

## Testing
- pytest tests/test_remote_data_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f126b58b908329b54431461bf9ff4a