### PR TITLE
Improve remote search hinting and MAST query translation

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -219,6 +219,24 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
 
 ---
 
+## 2025-10-16 23:58 – Remote catalogue hinting & query translation
+
+**Author**: agent
+
+**Context**: Remote catalogue search ergonomics and MAST adapter resilience.
+
+**Summary**: Wired provider-specific hints into the Remote Data dialog so users see
+which query styles NIST and MAST accept while typing, translated the MAST free-text
+field into `target_name` arguments both in the UI and the service layer, and added
+regression coverage that exercises the astroquery stub with the rewritten kwargs.
+Documentation now calls out the hint banner alongside the existing search
+instructions.【F:app/ui/remote_data_dialog.py†L17-L27】【F:app/ui/remote_data_dialog.py†L58-L131】【F:app/services/remote_data_service.py†L222-L279】【F:tests/test_remote_data_service.py†L169-L229】【F:docs/user/remote_data.md†L24-L33】
+
+**References**: `app/ui/remote_data_dialog.py`, `app/services/remote_data_service.py`,
+`tests/test_remote_data_service.py`, `docs/user/remote_data.md`.
+
+---
+
 ## 2025-10-16 21:45 – Knowledge Log Automation
 
 **Author**: agent

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,16 @@
 # Patch Notes
 
+## 2025-10-16 (Remote catalogue hinting & MAST text translation) (11:58 pm UTC)
+
+- Surfaced provider-specific search hints in the Remote Data dialog so the banner
+  explains when to enter NIST element symbols versus MAST target names or
+  `key=value` pairs.
+- Updated the MAST adapter to translate free-text queries into `target_name`
+  arguments before calling `astroquery.mast.Observations.query_criteria`, with
+  defensive coercion for non-string inputs.
+- Extended the remote data tests to cover the new translation path and refreshed
+  the user guide/knowledge log to document the hint banner behaviour.
+
 ## 2025-10-16 (Adjustable plot LOD budget) (11:55 pm UTC)
 
 - Added a configurable "LOD point budget" control to the Inspector Style tab so users can raise or lower the plot downsampling threshold from 1k to 1M samples while Spectra persists the preference via `QSettings`.

--- a/docs/user/remote_data.md
+++ b/docs/user/remote_data.md
@@ -27,6 +27,10 @@ them even when offline.
    - **MAST** treats free-form text as a `target_name`, or you can provide
      comma-separated `key=value` pairs for supported `astroquery.mast`
      parameters (for example `instrument_name=NIRSpec, dataproduct_type=spectrum`).
+4. Reference the hint banner below the buttons for provider-specific examples.
+   The dialog highlights when NIST expects an element/ion (such as `Fe II`) and
+   when MAST accepts target names or comma-separated arguments like
+   `instrument_name=NIRSpec`.
 
 The results table displays identifiers, titles, and the source URI for each
 match. Selecting a row shows the raw metadata payload in the preview panel so


### PR DESCRIPTION
## Summary
- surface provider-specific search hints in the remote data dialog so catalogue-specific examples are shown
- translate MAST free-text queries into target_name arguments in both the dialog and service with defensive handling
- extend remote data tests and refresh the user docs, knowledge log, and patch notes accordingly

## Testing
- pytest tests/test_remote_data_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f18659d9148329a600f4005cb4382a