### PR TITLE
Add library tab for cached imports and trim knowledge log noise

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -111,6 +111,10 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self._displayed_history_entries: List[KnowledgeLogEntry] = []
         self._history_ui_ready = False
 
+        self.dataset_tabs: Optional[QtWidgets.QTabWidget] = None
+        self.library_view: Optional[QtWidgets.QTreeWidget] = None
+        self._library_items: Dict[str, QtWidgets.QTreeWidgetItem] = {}
+
         self._plot_max_points = self._load_plot_max_points()
 
         self._setup_ui()
@@ -210,6 +214,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         else:
             self.store = LocalStore()
         self.ingest_service.store = self.store
+        self._refresh_library_view()
 
     def _setup_ui(self) -> None:
         self.central_split = QtWidgets.QSplitter(self)
@@ -256,7 +261,14 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.dataset_tree.header().setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
         self.dataset_tree.selectionModel().selectionChanged.connect(self._on_dataset_selection_changed)
         self.dataset_model.dataChanged.connect(self._on_dataset_data_changed)
-        self.dataset_dock.setWidget(self.dataset_tree)
+        self.dataset_tabs = QtWidgets.QTabWidget()
+        self.dataset_tabs.setObjectName("dataset-tabs")
+        self.dataset_tabs.addTab(self.dataset_tree, "Session")
+
+        self.library_view = self._build_library_view()
+        self.dataset_tabs.addTab(self.library_view, "Library")
+
+        self.dataset_dock.setWidget(self.dataset_tabs)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, self.dataset_dock)
 
         self._build_history_dock()
@@ -285,6 +297,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
 
         # Load documentation entries after all dock widgets (including the log view)
         # have been initialised so that the initial selection can log status safely.
+        self._refresh_library_view()
         self._load_documentation_index()
 
     def _build_history_dock(self) -> None:
@@ -538,6 +551,22 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.dataset_model.appendRow([alias_item, visible_item, color_item])
         return alias_item
 
+    def _build_library_view(self) -> QtWidgets.QTreeWidget:
+        view = QtWidgets.QTreeWidget()
+        view.setObjectName("library-view")
+        view.setRootIsDecorated(False)
+        view.setUniformRowHeights(True)
+        view.setAlternatingRowColors(True)
+        view.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        view.setHeaderLabels(["File", "SHA256", "Stored Path", "Size", "Importer"])
+        header = view.header()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
+        header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(4, QtWidgets.QHeaderView.ResizeToContents)
+        return view
+
     def _wire_shortcuts(self) -> None:
         QtGui.QShortcut(QtGui.QKeySequence("Ctrl+O"), self, activated=self.open_file)
         QtGui.QShortcut(QtGui.QKeySequence("U"), self, activated=self._cycle_units)
@@ -610,6 +639,7 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self.refresh_overlay()
         self._show_metadata(spectra[-1])
         self._show_provenance(spectra[-1])
+        self._refresh_library_view()
         message = f"Imported {len(spectra)} remote spectrum(s)."
         self.status_bar.showMessage(message, 5000)
         self._log("Remote", message)
@@ -818,18 +848,18 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         self._show_metadata(spectrum)
         self._show_provenance(spectrum)
         ingest_meta = spectrum.metadata.get("ingest", {}) if isinstance(spectrum.metadata, dict) else {}
-        importer = ingest_meta.get("importer", "Unknown importer")
-        summary = (
-            f"Ingested {spectrum.name} ({spectrum.id}) via {importer} from {path.name}."
-        )
-        references = [str(path)]
-        if spectrum.id:
-            references.append(spectrum.id)
-        cache_record = ingest_meta.get("cache_record", {}) if isinstance(ingest_meta, dict) else {}
-        cache_sha = cache_record.get("sha256")
-        if cache_sha:
-            references.append(str(cache_sha))
-        self._record_history_event("Import", summary, references)
+        importer = str(ingest_meta.get("importer", "Unknown importer"))
+        cache_record = ingest_meta.get("cache_record") if isinstance(ingest_meta, Mapping) else None
+        digest = ""
+        if isinstance(cache_record, Mapping):
+            sha = cache_record.get("sha256")
+            if isinstance(sha, str) and sha:
+                digest = sha[:10] + "…" if len(sha) > 10 else sha
+        if digest:
+            self._log("Library", f"Cached {spectrum.name} via {importer} ({digest}).")
+        else:
+            self._log("Library", f"Cached {spectrum.name} via {importer}.")
+        self._refresh_library_view()
 
     def _add_spectrum(self, spectrum: Spectrum) -> None:
         color = self._assign_color(spectrum)
@@ -884,6 +914,125 @@ class SpectraMainWindow(QtWidgets.QMainWindow):
         )
         self.plot.set_y_label(self._format_y_axis_label(display_y_unit))
         self.plot.autoscale()
+
+    # Library helpers --------------------------------------------------
+    def _refresh_library_view(self) -> None:
+        view = getattr(self, "library_view", None)
+        if view is None:
+            return
+
+        view.setUpdatesEnabled(False)
+        view.clear()
+        self._library_items.clear()
+
+        store = self.store or self.ingest_service.store
+        if store is None:
+            self._add_library_placeholder("Persistent cache is disabled. Enable it to build the library.")
+            view.setEnabled(False)
+            view.setUpdatesEnabled(True)
+            return
+
+        view.setEnabled(True)
+        try:
+            entries = store.list_entries()
+        except Exception as exc:  # pragma: no cover - filesystem feedback
+            self._add_library_placeholder(f"Unable to read cache: {exc}")
+            view.setEnabled(False)
+            view.setUpdatesEnabled(True)
+            return
+
+        if not entries:
+            self._add_library_placeholder("No cached files yet. Import spectra to build the library.")
+            view.setUpdatesEnabled(True)
+            return
+
+        sorter = lambda item: str(item[1].get("updated") or item[1].get("created") or "")
+        for sha, record in sorted(entries.items(), key=sorter, reverse=True):
+            columns = self._library_columns(record)
+            item = QtWidgets.QTreeWidgetItem(columns)
+            self._decorate_library_item(item, record)
+            view.addTopLevelItem(item)
+            if sha:
+                self._library_items[str(sha)] = item
+
+        view.setUpdatesEnabled(True)
+
+    def _library_columns(self, record: Mapping[str, Any]) -> list[str]:
+        filename = record.get("filename") if isinstance(record, Mapping) else None
+        stored_path = record.get("stored_path") if isinstance(record, Mapping) else None
+        original_path = record.get("original_path") if isinstance(record, Mapping) else None
+        sha = record.get("sha256") if isinstance(record, Mapping) else None
+        size = self._format_bytes(record.get("bytes") if isinstance(record, Mapping) else None)
+
+        if isinstance(filename, str) and filename:
+            label = filename
+        elif isinstance(original_path, str) and original_path:
+            label = Path(original_path).name
+        elif isinstance(stored_path, str) and stored_path:
+            label = Path(stored_path).name
+        elif isinstance(sha, str) and sha:
+            label = sha
+        else:
+            label = "Cached file"
+
+        stored_display = str(stored_path) if isinstance(stored_path, str) else ""
+
+        importer = ""
+        source = record.get("source") if isinstance(record, Mapping) else None
+        if isinstance(source, Mapping):
+            ingest = source.get("ingest")
+            if isinstance(ingest, Mapping):
+                importer = str(ingest.get("importer") or "")
+
+        return [
+            label,
+            str(sha or ""),
+            stored_display,
+            size,
+            importer,
+        ]
+
+    def _decorate_library_item(self, item: QtWidgets.QTreeWidgetItem, record: Mapping[str, Any]) -> None:
+        stored_path = record.get("stored_path") if isinstance(record, Mapping) else None
+        original_path = record.get("original_path") if isinstance(record, Mapping) else None
+        tooltip_lines = [item.text(0)]
+        if isinstance(stored_path, str) and stored_path:
+            tooltip_lines.append(f"Stored at: {stored_path}")
+        if (
+            isinstance(original_path, str)
+            and original_path
+            and original_path != stored_path
+        ):
+            tooltip_lines.append(f"Original path: {original_path}")
+        item.setToolTip(0, "\n".join(filter(None, tooltip_lines)))
+
+        for col in range(1, item.columnCount()):
+            text = item.text(col)
+            if text:
+                item.setToolTip(col, text)
+
+    def _add_library_placeholder(self, message: str) -> None:
+        view = getattr(self, "library_view", None)
+        if view is None:
+            return
+        placeholder = QtWidgets.QTreeWidgetItem([message, "", "", "", ""])
+        placeholder.setFlags(QtCore.Qt.ItemFlag.NoItemFlags)
+        view.addTopLevelItem(placeholder)
+        view.setFirstColumnSpanned(placeholder, True)
+
+    @staticmethod
+    def _format_bytes(value: object) -> str:
+        if not isinstance(value, (int, float)):
+            return ""
+        size = float(value)
+        units = ["B", "KB", "MB", "GB", "TB"]
+        for unit in units:
+            if size < 1024 or unit == units[-1]:
+                if unit == "B":
+                    return f"{int(size)} {unit}"
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{int(value)} B"
 
     def _show_metadata(self, spectrum: Spectrum | None) -> None:
         if spectrum is None:

--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -5,7 +5,12 @@ This file serves as the single entry point for all historical notes, patches,
 information in many places (e.g. `brains`, `atlas`, `PATCHLOG.txt`) and often
 used confusing naming schemes (sometimes based on the day of the month)【875267955107972†L63-L74】.
 To avoid further fragmentation, every meaningful change or insight should be
-recorded here with a timestamp and a clear description.
+recorded here with a timestamp and a clear description. Routine ingest
+metadata now lives in the in-app **Library** view (Datasets dock → Library tab),
+which is backed by the persistent cache. Use that panel to audit file-level
+details such as SHA256 hashes, source paths, and importer provenance. The
+knowledge log captures the why behind changes and high-level operational
+decisions rather than enumerating every imported file.
 
 ## Log Format
 
@@ -40,7 +45,10 @@ The desktop preview now ships with a `KnowledgeLogService` that writes
 automation events into this file by default.  The service can also be pointed
 at an alternative runtime location (e.g. a temporary path during tests) by
 passing a custom `log_path`, ensuring automated provenance never tramples the
-canonical history while still following the structure defined here.
+canonical history while still following the structure defined here. Import
+actions are summarised at the session level; per-file cache entries are stored
+in the Library view so the log remains focused on insights and operator
+decisions.
 
 ## Example Entry
 
@@ -85,6 +93,9 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
 * **Completeness**: Include enough information for future developers or
   agents to understand the context without having to search through commit
   history.  When in doubt, write more rather than less.
+* **Operational focus**: Keep per-file provenance (paths, hashes, importer
+  IDs) in the Library view. The knowledge log should summarise what changed,
+  why it matters, and how it affects workflows.
 * **Citation**: Use tether IDs to cite official documents, academic papers or
   authoritative resources.  This ensures that claims can be verified.
 

--- a/docs/user/importing.md
+++ b/docs/user/importing.md
@@ -45,6 +45,18 @@ Imported spectra always appear in canonical units inside the application. Use
  underlying data. The raw source file remains untouched in the provenance
  bundle created during export.
 
+### Reviewing cached artefacts
+
+- Open the **Datasets** dock and switch to the **Library** tab to inspect
+  everything the LocalStore cache has captured. Each entry lists the stored
+  filename, SHA256 digest, on-disk location, byte size, and importer ID.
+- Use this view to confirm that repeated ingests map to the same digest or to
+  browse previously cached files without scrolling through the knowledge log.
+- The **History** dock now focuses on summarised insights (for example “Batch
+  of calibration frames loaded for detector QA”). Per-file import noise no
+  longer lands in `docs/history/KNOWLEDGE_LOG.md`, keeping the log readable
+  while the Library surfaces the low-level provenance.
+
 ## Intelligent parsing of messy tables
 
 Field notebooks and vendor exports rarely follow a pristine two-column layout.

--- a/tests/test_library_view.py
+++ b/tests/test_library_view.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+try:
+    from app import main as main_mod
+    from app.main import SpectraMainWindow
+    from app.qt_compat import get_qt
+    from app.services import KnowledgeLogService, LocalStore
+except ImportError as exc:  # pragma: no cover - optional on headless CI
+    SpectraMainWindow = None  # type: ignore[assignment]
+    main_mod = None  # type: ignore[assignment]
+    _qt_import_error = exc
+    QtCore = QtGui = QtWidgets = None  # type: ignore[assignment]
+    KnowledgeLogService = LocalStore = None  # type: ignore[assignment]
+else:  # pragma: no cover - exercised via regression test
+    _qt_import_error = None
+    QtCore, QtGui, QtWidgets, _ = get_qt()
+
+
+def _ensure_app() -> QtWidgets.QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def test_library_view_populates_and_skips_import_history(tmp_path, monkeypatch):
+    if (
+        SpectraMainWindow is None
+        or QtWidgets is None
+        or KnowledgeLogService is None
+        or LocalStore is None
+        or main_mod is None
+    ):
+        pytest.skip(f"Qt stack unavailable: {_qt_import_error}")
+
+    app = _ensure_app()
+
+    empty_samples = tmp_path / "samples"
+    empty_samples.mkdir()
+    monkeypatch.setattr(main_mod, "SAMPLES_DIR", empty_samples)
+
+    log_path = tmp_path / "log.md"
+    knowledge_log = KnowledgeLogService(log_path=log_path)
+
+    window = SpectraMainWindow(knowledge_log_service=knowledge_log)
+    try:
+        window.store = LocalStore(base_dir=tmp_path / "store")
+        window.ingest_service.store = window.store
+        window._refresh_library_view()
+        app.processEvents()
+
+        assert window.library_view is not None
+        assert window.library_view.topLevelItemCount() == 1
+        placeholder = window.library_view.topLevelItem(0)
+        assert "No cached files" in placeholder.text(0)
+
+        sample = Path(__file__).resolve().parent / "data" / "mini.csv"
+        window._ingest_path(sample)
+        app.processEvents()
+        window._refresh_library_view()
+
+        items = [
+            window.library_view.topLevelItem(index).text(0)
+            for index in range(window.library_view.topLevelItemCount())
+        ]
+        assert any("mini.csv" in text for text in items)
+
+        import_entries = knowledge_log.load_entries(component="Import")
+        assert import_entries == []
+    finally:
+        window.close()
+        window.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- add a LocalStore-backed Library tab to the datasets dock and refresh ingestion so cached files surface there instead of logging raw paths
- limit knowledge-log automation to high-level summaries and document the split between the Library view and the consolidated log
- add regression coverage that exercises the Library view population and verifies import events no longer write verbose entries

## Testing
- pytest tests/test_library_view.py
- pytest tests/test_knowledge_log_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f1924ec1c08329815c1c9a258dc2cf