### PR TITLE
Surface remote provenance in library view and reduce knowledge log noise

### DIFF
--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -45,9 +45,9 @@ automation events into this file by default.  The service can also be pointed
 at an alternative runtime location (e.g. a temporary path during tests) by
 passing a custom `log_path`, ensuring automated provenance never tramples the
 canonical history while still following the structure defined here. Import
-actions are summarised at the session level; per-file cache entries are stored
-in the Library view so the log remains focused on insights and operator
-decisions.
+actions are summarised at the session level; per-file cache entries (including
+remote URIs and SHA256 digests) are stored in the Library view so the log
+remains focused on insights and operator decisions.
 
 ## Example Entry
 
@@ -93,8 +93,9 @@ To migrate existing `brains` and `atlas` logs, follow these steps:
   agents to understand the context without having to search through commit
   history.  When in doubt, write more rather than less.
 * **Operational focus**: Keep per-file provenance (paths, hashes, importer
-  IDs) in the Library view. The knowledge log should summarise what changed,
-  why it matters, and how it affects workflows.
+  IDs, remote URIs) in the Library view. The knowledge log should summarise
+  what changed, why it matters, and how it affects workflows without duplicating
+  the cache index.
 * **Citation**: Use tether IDs to cite official documents, academic papers or
   authoritative resources.  This ensures that claims can be verified.
 


### PR DESCRIPTION
## Summary
- extend the Library tab with an origin column, remote tooltips, and slimmer remote import history entries
- merge LocalStore source metadata so remote URIs and checksums persist in the cache index and align documentation with the policy
- add regression coverage that exercises the Library view, verifies provenance retention, and asserts the knowledge log omits verbose references

## Testing
- pytest tests/test_library_view.py -q


------
https://chatgpt.com/codex/tasks/task_e_68f1a675342c83298656db7d23385a73