### PR TITLE
Guard MAST queries against empty filters

### DIFF
--- a/app/services/remote_data_service.py
+++ b/app/services/remote_data_service.py
@@ -225,6 +225,16 @@ class RemoteDataService:
             if isinstance(legacy_text, str) and legacy_text.strip():
                 criteria["target_name"] = legacy_text.strip()
 
+        provided_narrowing_keys = [
+            key for key in criteria if key in self._MAST_SUPPORTED_CRITERIA
+        ]
+        if not provided_narrowing_keys:
+            supported = ", ".join(sorted(self._MAST_SUPPORTED_CRITERIA))
+            raise ValueError(
+                "MAST searches require a target name or one of the supported filters to bound the result set. "
+                f"Recognised filters: {supported}."
+            )
+
         # Default to calibrated spectroscopic products so search results focus on
         # slit/grism/cube observations that pair with laboratory references.
         criteria.setdefault("dataproduct_type", "spectrum")

--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -33,6 +33,24 @@ Each entry in this document should follow this structure:
 
 ---
 
+## 2025-10-18 09:10 – Remote MAST validation
+
+**Author**: agent
+
+**Context**: Remote catalogue guard rails.
+
+**Summary**: Tightened the Remote Data workflow so blank MAST requests are blocked
+in the dialog and the service refuses unbounded astroquery calls. The UI now
+explains why a search was rejected, while the adapter raises a descriptive error
+when no recognised filters are supplied. Regression coverage asserts the guard
+rails and documentation highlights the requirement for bounded MAST criteria.
+
+**References**: `app/ui/remote_data_dialog.py`, `app/services/remote_data_service.py`,
+`tests/test_remote_data_dialog.py`, `tests/test_remote_data_service.py`,
+`docs/user/remote_data.md`, `docs/history/PATCH_NOTES.md`.
+
+---
+
 ## 2025-10-17 18:40 – Library knowledge-log surfacing
 
 **Author**: agent

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,17 @@
 # Patch Notes
 
+## 2025-10-18 (MAST search validation) (09:10 UTC)
+
+- Blocked empty MAST submissions in the Remote Data dialog, surfacing a validation
+  hint so operators add target names or supported key=value filters before
+  dispatching a search.
+- Guarded the MAST adapter against unbounded astroquery lookups by requiring at
+  least one recognised criterion (`target_name`, `instrument_name`, etc.) and
+  raising a descriptive error when none are provided.
+- Documented the stricter requirements and refreshed the regression suite to
+  cover the UI validation path and ensure blank requests never hit
+  `Observations.query_criteria`.
+
 ## 2025-10-17 (Library detail knowledge-log links) (18:40 UTC)
 
 - Extended the Library dock detail pane so selecting a cache record surfaces

--- a/docs/reviews/workplan.md
+++ b/docs/reviews/workplan.md
@@ -4,6 +4,9 @@ This document tracks feature batches, validation status, and outstanding backlog
 
 ## Batch 14 (2025-10-17) — In Progress
 
+- [x] Block blank MAST queries by validating Remote Data input, adding service
+      guards, documentation, and regression tests so astroquery calls stay
+      bounded.
 - [x] Align Remote Data searches with provider-specific criteria so MAST queries pass `target_name` while NIST continues to use `spectra` filters, and extend the regression suite to cover the translation.
 - [x] Route MAST downloads through `astroquery.mast.Observations.download_file`, retaining the HTTP code path for direct URLs and persisting results via `LocalStore`.
 - [x] Separate routine ingest bookkeeping from the Knowledge Log by introducing a cached-library view backed by `LocalStore` and limiting the log to distilled insights. Update the documentation to reflect the new policy.
@@ -21,6 +24,7 @@ This document tracks feature batches, validation status, and outstanding backlog
 
 ### Batch 14 QA Log
 
+- 2025-10-18: ✅ `pytest` (remote MAST validation)
 - 2025-10-17: ✅ `pytest`
 - 2025-10-17: ✅ `pytest` (library detail refresh)
 

--- a/docs/user/remote_data.md
+++ b/docs/user/remote_data.md
@@ -30,6 +30,8 @@ directly against laboratory references.
    - **MAST** converts free-form text into a `target_name`, or you can provide
      comma-separated `key=value` pairs for supported `astroquery.mast`
      parameters (for example `instrument_name=NIRSpec, dataproduct_type=spectrum`).
+     Blank submissions are blocked because MAST requires a target name or
+     narrowing filters to avoid unbounded catalogue scans.
 4. Reference the hint banner below the buttons for provider-specific examples.
    The dialog surfaces the mapping so you know when NIST expects an element/ion
    such as `Fe II`, and when MAST accepts target names or comma-separated
@@ -58,6 +60,8 @@ When you switch between catalogues the banner updates in real time:
   instrument identifiers (e.g. `WASP-96 b`, `NIRSpec grism`) to favour
   calibrated spectroscopic products (IFS cubes, slit/grism/prism extractions)
   instead of broad-band imaging or photometric light curves.
+  The dialog enforces this by refusing empty submissions and explaining why the
+  query was rejected whenever no recognised filter is present.
 
 The hint banner beneath the results table updates as you switch providers and
 also surfaces dependency warnings when optional clients are missing.


### PR DESCRIPTION
## Summary
- block blank MAST submissions in the Remote Data dialog and support parsing numeric filters before invoking the service
- require recognised criteria in the MAST adapter to prevent unbounded astroquery queries and raise a descriptive error when missing
- extend regression coverage and documentation, including patch notes, knowledge log, and workplan updates for the new validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f25616c71883299509c7eb0be1d122