### PR TITLE
Harden remote data validation for empty searches

### DIFF
--- a/app/ui/remote_data_dialog.py
+++ b/app/ui/remote_data_dialog.py
@@ -127,6 +127,23 @@ class RemoteDataDialog(QtWidgets.QDialog):
         provider = self.provider_combo.currentText()
         query = self._build_provider_query(provider, self.search_edit.text())
 
+        if not query:
+            if provider == RemoteDataService.PROVIDER_MAST:
+                message = (
+                    "MAST searches require a target name or supported key=value filters before running a query."
+                )
+            elif provider == RemoteDataService.PROVIDER_NIST:
+                message = (
+                    "NIST ASD searches require an element, ion, or keyword before running a query."
+                )
+            else:
+                message = "Enter search terms before querying the selected catalogue."
+            self.status_label.setText(message)
+            self._records = []
+            self.results.setRowCount(0)
+            self.preview.clear()
+            return
+
         if provider == RemoteDataService.PROVIDER_MAST and not any(
             key in self._MAST_SUPPORTED_CRITERIA for key in query
         ):

--- a/docs/history/KNOWLEDGE_LOG.md
+++ b/docs/history/KNOWLEDGE_LOG.md
@@ -33,6 +33,25 @@ Each entry in this document should follow this structure:
 
 ---
 
+## 2025-10-19 08:30 – Remote search guard rails
+
+**Author**: agent
+
+**Context**: Remote catalogue validation UX and service safety nets.
+
+**Summary**: Hardened the Remote Data workflow so blank submissions stop in the
+dialog with provider-specific guidance while the NIST/MAST adapters raise
+`ValueError` when automation callers omit narrowing terms. Regression coverage
+now clicks the UI button for empty queries and asserts the NIST service refuses
+empty payloads, and the troubleshooting guide documents the required filters.
+
+**References**: `app/ui/remote_data_dialog.py`,
+`app/services/remote_data_service.py`, `tests/test_remote_data_dialog.py`,
+`tests/test_remote_data_service.py`, `docs/user/remote_data.md`,
+`docs/history/PATCH_NOTES.md`.
+
+---
+
 ## 2025-10-18 09:10 – Remote MAST validation
 
 **Author**: agent

--- a/docs/history/PATCH_NOTES.md
+++ b/docs/history/PATCH_NOTES.md
@@ -1,5 +1,17 @@
 # Patch Notes
 
+## 2025-10-19 (Remote search input validation) (08:30 UTC)
+
+- Blocked empty submissions for every provider in the Remote Data dialog so the
+  UI now highlights when NIST or MAST requests are missing required criteria
+  before the service layer is invoked.
+- Raised explicit `ValueError` exceptions in the NIST and MAST adapters when
+  automation callers omit narrowing filters, keeping legacy entry points from
+  issuing unbounded catalogue queries.
+- Documented the stricter troubleshooting guidance, refreshed the dialog smoke
+  tests to drive button clicks, and added a service regression that expects the
+  new error path for NIST.
+
 ## 2025-10-18 (MAST search validation) (09:10 UTC)
 
 - Blocked empty MAST submissions in the Remote Data dialog, surfacing a validation

--- a/docs/user/remote_data.md
+++ b/docs/user/remote_data.md
@@ -66,6 +66,20 @@ When you switch between catalogues the banner updates in real time:
 The hint banner beneath the results table updates as you switch providers and
 also surfaces dependency warnings when optional clients are missing.
 
+## Troubleshooting
+
+- **NIST ASD** – Leave the field blank and the dialog will stop the request,
+  explaining that the catalogue needs an element, ion, or keyword. The backing
+  service now raises a `ValueError` for automation callers that bypass the UI,
+  so scripts must always supply meaningful `spectra`/`element` text before
+  contacting the endpoint.
+- **MAST** – Searches must include a target name or one of the supported
+  `astroquery.mast.Observations.query_criteria` filters:
+  `target_name`, `obs_collection`, `dataproduct_type`, `instrument_name`,
+  `proposal_id`, `proposal_pi`, `filters`, `s_ra`, `s_dec`, or `radius`.
+  The dialog surfaces the warning immediately and the adapter raises a
+  `ValueError` if automation code submits an empty or whitespace-only payload.
+
 ### Provider-specific search tips
 
 - **NIST ASD** – The query box maps to the catalogue’s `spectra` filter. Enter

--- a/tests/test_remote_data_dialog.py
+++ b/tests/test_remote_data_dialog.py
@@ -86,10 +86,35 @@ def test_mast_blank_query_surfaces_validation(monkeypatch: Any) -> None:
     index = dialog.provider_combo.findText(RemoteDataService.PROVIDER_MAST)
     dialog.provider_combo.setCurrentIndex(index)
     dialog.search_edit.setText("   ")
-    dialog._on_search()
+    dialog.search_button.click()
+    app.processEvents()
 
     assert remote.search_calls == 0
     assert "MAST searches require" in dialog.status_label.text()
+
+    dialog.deleteLater()
+    if QtWidgets.QApplication.instance() is app and not app.topLevelWidgets():
+        app.quit()
+
+
+def test_nist_blank_query_surfaces_validation(monkeypatch: Any) -> None:
+    app = _ensure_app()
+    ingest = IngestServiceStub()
+    remote = StubRemoteService()
+    dialog = RemoteDataDialog(
+        None,
+        remote_service=remote,
+        ingest_service=ingest,
+    )
+
+    index = dialog.provider_combo.findText(RemoteDataService.PROVIDER_NIST)
+    dialog.provider_combo.setCurrentIndex(index)
+    dialog.search_edit.clear()
+    dialog.search_button.click()
+    app.processEvents()
+
+    assert remote.search_calls == 0
+    assert "NIST ASD searches require" in dialog.status_label.text()
 
     dialog.deleteLater()
     if QtWidgets.QApplication.instance() is app and not app.topLevelWidgets():

--- a/tests/test_remote_data_service.py
+++ b/tests/test_remote_data_service.py
@@ -70,6 +70,17 @@ def test_search_mast_requires_target_or_filters(store: LocalStore, monkeypatch: 
     assert DummyObservations.called is False
 
 
+def test_search_nist_requires_element(store: LocalStore) -> None:
+    session = DummySession()
+    service = RemoteDataService(store, session=session)
+
+    with pytest.raises(ValueError) as excinfo:
+        service.search(RemoteDataService.PROVIDER_NIST, {})
+
+    assert "element" in str(excinfo.value)
+    assert session.calls == []
+
+
 def test_search_nist_constructs_url_and_params(store: LocalStore) -> None:
     session = DummySession()
     session.queue(


### PR DESCRIPTION
## Summary
- short-circuit the Remote Data dialog when the provider query is empty and surface provider-specific guidance
- raise `ValueError` for empty criteria in the NIST and MAST adapters while trimming blank values before invoking astroquery
- document the required inputs and extend the regression suite plus history logs for the new validation paths

## Testing
- pytest tests/test_remote_data_dialog.py tests/test_remote_data_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f29073e32083299895f649577e053a